### PR TITLE
Optimize walk gaits

### DIFF
--- a/march_gait_files/airgait/walk/left_swing/MIV_1,1sec_ankle_0.subgait
+++ b/march_gait_files/airgait/walk/left_swing/MIV_1,1sec_ankle_0.subgait
@@ -1,0 +1,150 @@
+name: ''
+version: ''
+description: "The setpoints of this walking gait are the same as the setpoints of the MIII walking\
+  \ gait, except for the fact that the timing of the setpoints in different."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_fe, left_knee, right_hip_fe, right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  27500000
+    joint_names: [left_hip_aa, left_ankle, right_hip_aa, right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 220000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 412500000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 462000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 660000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 748000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 990000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 100000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0, 0.0, 0.3142, 0.1396, 0.0]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1648, 0.1437, 0.0, 0.0, 0.3069, 0.1413, 0.0]
+      velocities: [0.0, 0.1414, 0.3014, 0.0, 0.0, -0.3657, 0.1216, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  27500000
+    - 
+      positions: [0.0, 0.0031, 0.4609, 0.0, 0.0, 0.2193, 0.2094, 0.0]
+      velocities: [0.0, 1.3723, 2.3539, 0.0, 0.0, -0.5241, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 220000000
+    - 
+      positions: [0.0, 0.3019, 0.8406, 0.0, 0.0, 0.111, 0.1899, 0.0]
+      velocities: [0.0, 1.5609, 1.1265, 0.0, 0.0, -0.5867, -0.1775, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 412500000
+    - 
+      positions: [0.0, 0.3772, 0.8727, 0.0, 0.0, 0.0813, 0.1804, 0.0]
+      velocities: [0.0, 1.4374, 0.0, 0.0, 0.0, -0.5873, -0.1948, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 462000000
+    - 
+      positions: [0.0, 0.4891, 0.8213, 0.0, 0.0, 0.0286, 0.1626, 0.0]
+      velocities: [0.0, 1.0331, -1.1086, 0.0, 0.0, -0.5716, -0.1894, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [0.0, 0.5585, 0.6355, 0.0, 0.0, -0.0322, 0.1452, 0.0]
+      velocities: [0.0, 0.1396, -2.0254, 0.0, 0.0, -0.5232, -0.119, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 660000000
+    - 
+      positions: [0.0, 0.5463, 0.4391, 0.0, 0.0, -0.0767, 0.1396, 0.0]
+      velocities: [0.0, -0.3599, -2.1959, 0.0, 0.0, -0.4598, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 748000000
+    - 
+      positions: [0.0, 0.3776, 0.0969, 0.0, 0.0, -0.1565, 0.1396, 0.0]
+      velocities: [0.0, -0.745, 0.0, 0.0, 0.0, -0.1855, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 990000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0, 0.0, -0.1667, 0.1396, 0.0]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 100000000
+duration: 
+  secs: 1
+  nsecs: 100000000
+sounds: []

--- a/march_gait_files/airgait/walk/left_swing/MIV_1,1sec_ankle_2.5.subgait
+++ b/march_gait_files/airgait/walk/left_swing/MIV_1,1sec_ankle_2.5.subgait
@@ -1,0 +1,150 @@
+name: ''
+version: ''
+description: "The setpoints of this walking gait are the same as the setpoints of the MIII walking\
+  \ gait, except for the fact that the timing of the setpoints in different."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_fe, left_knee, right_hip_fe, right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  27500000
+    joint_names: [left_hip_aa, left_ankle, right_hip_aa, right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 220000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 412500000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 462000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 660000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 748000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 990000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 100000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1648, 0.1437, 0.0436, 0.0, 0.3069, 0.1413, 0.0436]
+      velocities: [0.0, 0.1414, 0.3014, 0.0, 0.0, -0.3657, 0.1216, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  27500000
+    - 
+      positions: [0.0, 0.0031, 0.4609, 0.0436, 0.0, 0.2193, 0.2094, 0.0436]
+      velocities: [0.0, 1.3723, 2.3539, 0.0, 0.0, -0.5241, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 220000000
+    - 
+      positions: [0.0, 0.3019, 0.8406, 0.0436, 0.0, 0.111, 0.1899, 0.0436]
+      velocities: [0.0, 1.5609, 1.1265, 0.0, 0.0, -0.5867, -0.1775, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 412500000
+    - 
+      positions: [0.0, 0.3772, 0.8727, 0.0436, 0.0, 0.0813, 0.1804, 0.0436]
+      velocities: [0.0, 1.4374, 0.0, 0.0, 0.0, -0.5873, -0.1948, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 462000000
+    - 
+      positions: [0.0, 0.4891, 0.8213, 0.0436, 0.0, 0.0286, 0.1626, 0.0436]
+      velocities: [0.0, 1.0331, -1.1086, -0.0, 0.0, -0.5716, -0.1894, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [0.0, 0.5585, 0.6355, 0.0436, 0.0, -0.0322, 0.1452, 0.0436]
+      velocities: [0.0, 0.1396, -2.0254, 0.0, 0.0, -0.5232, -0.119, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 660000000
+    - 
+      positions: [0.0, 0.5463, 0.4391, 0.0436, 0.0, -0.0767, 0.1396, 0.0436]
+      velocities: [0.0, -0.3599, -2.1959, 0.0, 0.0, -0.4598, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 748000000
+    - 
+      positions: [0.0, 0.3776, 0.0969, 0.0436, 0.0, -0.1565, 0.1396, 0.0436]
+      velocities: [0.0, -0.745, 0.0, 0.0, 0.0, -0.1855, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 990000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 100000000
+duration: 
+  secs: 1
+  nsecs: 100000000
+sounds: []

--- a/march_gait_files/airgait/walk/left_swing/MIV_1,1sec_ankle_5.subgait
+++ b/march_gait_files/airgait/walk/left_swing/MIV_1,1sec_ankle_5.subgait
@@ -1,0 +1,150 @@
+name: ''
+version: ''
+description: "The setpoints of this walking gait are the same as the setpoints of the MIII walking\
+  \ gait, except for the fact that the timing of the setpoints in different."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_fe, left_knee, right_hip_fe, right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  27500000
+    joint_names: [left_hip_aa, left_ankle, right_hip_aa, right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 220000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 412500000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 462000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 660000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 748000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 990000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 100000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0873, 0.0, 0.3142, 0.1396, 0.0873]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1648, 0.1437, 0.0873, 0.0, 0.3069, 0.1413, 0.0873]
+      velocities: [0.0, 0.1414, 0.3014, 0.0, 0.0, -0.3657, 0.1216, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  27500000
+    - 
+      positions: [0.0, 0.0031, 0.4609, 0.0873, 0.0, 0.2193, 0.2094, 0.0873]
+      velocities: [0.0, 1.3723, 2.3539, 0.0, 0.0, -0.5241, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 220000000
+    - 
+      positions: [0.0, 0.3019, 0.8406, 0.0873, 0.0, 0.111, 0.1899, 0.0873]
+      velocities: [0.0, 1.5609, 1.1265, 0.0, 0.0, -0.5867, -0.1775, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 412500000
+    - 
+      positions: [0.0, 0.3772, 0.8727, 0.0873, 0.0, 0.0813, 0.1804, 0.0873]
+      velocities: [0.0, 1.4374, 0.0, 0.0, 0.0, -0.5873, -0.1948, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 462000000
+    - 
+      positions: [0.0, 0.4891, 0.8213, 0.0873, 0.0, 0.0286, 0.1626, 0.0873]
+      velocities: [0.0, 1.0331, -1.1086, -0.0, 0.0, -0.5716, -0.1894, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [0.0, 0.5585, 0.6355, 0.0873, 0.0, -0.0322, 0.1452, 0.0873]
+      velocities: [0.0, 0.1396, -2.0254, 0.0, 0.0, -0.5232, -0.119, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 660000000
+    - 
+      positions: [0.0, 0.5463, 0.4391, 0.0873, 0.0, -0.0767, 0.1396, 0.0873]
+      velocities: [0.0, -0.3599, -2.1959, 0.0, 0.0, -0.4598, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 748000000
+    - 
+      positions: [0.0, 0.3776, 0.0969, 0.0873, 0.0, -0.1565, 0.1396, 0.0873]
+      velocities: [0.0, -0.745, 0.0, 0.0, 0.0, -0.1855, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 990000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0873, 0.0, -0.1667, 0.1396, 0.0873]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 100000000
+duration: 
+  secs: 1
+  nsecs: 100000000
+sounds: []

--- a/march_gait_files/airgait/walk/left_swing/MIV_more_knee_flexion_1,2sec_ankle_0.subgait
+++ b/march_gait_files/airgait/walk/left_swing/MIV_more_knee_flexion_1,2sec_ankle_0.subgait
@@ -1,0 +1,150 @@
+name: ''
+version: ''
+description: "The setpoints of this walking gait are the same as the setpoints of the MIII walking\
+  \ gait, except for the fact that the timing of the setpoints in different."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_fe, left_knee, right_hip_fe, right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  30000000
+    joint_names: [left_hip_aa, left_ankle, right_hip_aa, right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 240000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 450000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 504000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 720000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 816000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  80000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0, 0.0, 0.3142, 0.1396, 0.0]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1651, 0.1435, 0.0, 0.0, 0.3069, 0.141, 0.0]
+      velocities: [0.0, 0.1195, 0.2863, 0.0, 0.0, -0.3617, 0.1036, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  30000000
+    - 
+      positions: [0.0, 0.006, 0.5056, 0.0, 0.0, 0.2136, 0.2094, 0.0]
+      velocities: [0.0, 1.2637, 2.4204, 0.0, 0.0, -0.492, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 240000000
+    - 
+      positions: [0.0, 0.3107, 0.9312, 0.0, 0.0, 0.102, 0.1888, 0.0]
+      velocities: [0.0, 1.4182, 1.0477, 0.0, 0.0, -0.5363, -0.1657, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 450000000
+    - 
+      positions: [0.0, 0.3798, 0.9599, 0.0, 0.0, 0.0748, 0.1799, 0.0]
+      velocities: [0.0, 1.3091, 0.0, 0.0, 0.0, -0.5342, -0.1791, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 504000000
+    - 
+      positions: [0.0, 0.4931, 0.896, 0.0, 0.0, 0.0214, 0.1617, 0.0]
+      velocities: [0.0, 0.9226, -1.1947, 0.0, 0.0, -0.5153, -0.1719, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.5585, 0.7038, 0.0, 0.0, -0.0338, 0.1456, 0.0]
+      velocities: [0.0, 0.1396, -2.0504, 0.0, 0.0, -0.472, -0.1117, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 720000000
+    - 
+      positions: [0.0, 0.5479, 0.48, 0.0, 0.0, -0.0787, 0.1396, 0.0]
+      velocities: [0.0, -0.315, -2.2398, 0.0, 0.0, -0.4122, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 816000000
+    - 
+      positions: [0.0, 0.3805, 0.0969, 0.0, 0.0, -0.1567, 0.1396, 0.0]
+      velocities: [0.0, -0.6918, 0.0, 0.0, 0.0, -0.1655, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  80000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0, 0.0, -0.1667, 0.1396, 0.0]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+duration: 
+  secs: 1
+  nsecs: 199999999
+sounds: []

--- a/march_gait_files/airgait/walk/left_swing/MIV_more_knee_flexion_1,2sec_ankle_2.5.subgait
+++ b/march_gait_files/airgait/walk/left_swing/MIV_more_knee_flexion_1,2sec_ankle_2.5.subgait
@@ -1,0 +1,150 @@
+name: ''
+version: ''
+description: "The setpoints of this walking gait are the same as the setpoints of the MIII walking\
+  \ gait, except for the fact that the timing of the setpoints in different."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_fe, left_knee, right_hip_fe, right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  30000000
+    joint_names: [left_hip_aa, left_ankle, right_hip_aa, right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 240000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 450000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 504000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 720000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 816000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  80000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1651, 0.1435, 0.0436, 0.0, 0.3069, 0.141, 0.0436]
+      velocities: [0.0, 0.1195, 0.2863, 0.0, 0.0, -0.3617, 0.1036, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  30000000
+    - 
+      positions: [0.0, 0.006, 0.5056, 0.0436, 0.0, 0.2136, 0.2094, 0.0436]
+      velocities: [0.0, 1.2637, 2.4204, -0.0, 0.0, -0.492, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 240000000
+    - 
+      positions: [0.0, 0.3107, 0.9312, 0.0436, 0.0, 0.102, 0.1888, 0.0436]
+      velocities: [0.0, 1.4182, 1.0477, 0.0, 0.0, -0.5363, -0.1657, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 450000000
+    - 
+      positions: [0.0, 0.3798, 0.9599, 0.0436, 0.0, 0.0748, 0.1799, 0.0436]
+      velocities: [0.0, 1.3091, 0.0, 0.0, 0.0, -0.5342, -0.1791, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 504000000
+    - 
+      positions: [0.0, 0.4931, 0.896, 0.0436, 0.0, 0.0214, 0.1617, 0.0436]
+      velocities: [0.0, 0.9226, -1.1947, 0.0, 0.0, -0.5153, -0.1719, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.5585, 0.7038, 0.0436, 0.0, -0.0338, 0.1456, 0.0436]
+      velocities: [0.0, 0.1396, -2.0504, 0.0, 0.0, -0.472, -0.1117, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 720000000
+    - 
+      positions: [0.0, 0.5479, 0.48, 0.0436, 0.0, -0.0787, 0.1396, 0.0436]
+      velocities: [0.0, -0.315, -2.2398, 0.0, 0.0, -0.4122, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 816000000
+    - 
+      positions: [0.0, 0.3805, 0.0969, 0.0436, 0.0, -0.1567, 0.1396, 0.0436]
+      velocities: [0.0, -0.6918, 0.0, 0.0, 0.0, -0.1655, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  80000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+duration: 
+  secs: 1
+  nsecs: 199999999
+sounds: []

--- a/march_gait_files/airgait/walk/left_swing/MIV_more_knee_flexion_1,2sec_ankle_5.subgait
+++ b/march_gait_files/airgait/walk/left_swing/MIV_more_knee_flexion_1,2sec_ankle_5.subgait
@@ -1,0 +1,150 @@
+name: ''
+version: ''
+description: "The setpoints of this walking gait are the same as the setpoints of the MIII walking\
+  \ gait, except for the fact that the timing of the setpoints in different."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_fe, left_knee, right_hip_fe, right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  30000000
+    joint_names: [left_hip_aa, left_ankle, right_hip_aa, right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 240000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 450000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 504000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 720000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 816000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  80000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0873, 0.0, 0.3142, 0.1396, 0.0873]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1651, 0.1435, 0.0873, 0.0, 0.3069, 0.141, 0.0873]
+      velocities: [0.0, 0.1195, 0.2863, 0.0, 0.0, -0.3617, 0.1036, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  30000000
+    - 
+      positions: [0.0, 0.006, 0.5056, 0.0873, 0.0, 0.2136, 0.2094, 0.0873]
+      velocities: [0.0, 1.2637, 2.4204, -0.0, 0.0, -0.492, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 240000000
+    - 
+      positions: [0.0, 0.3107, 0.9312, 0.0873, 0.0, 0.102, 0.1888, 0.0873]
+      velocities: [0.0, 1.4182, 1.0477, -0.0, 0.0, -0.5363, -0.1657, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 450000000
+    - 
+      positions: [0.0, 0.3798, 0.9599, 0.0873, 0.0, 0.0748, 0.1799, 0.0873]
+      velocities: [0.0, 1.3091, 0.0, 0.0, 0.0, -0.5342, -0.1791, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 504000000
+    - 
+      positions: [0.0, 0.4931, 0.896, 0.0873, 0.0, 0.0214, 0.1617, 0.0873]
+      velocities: [0.0, 0.9226, -1.1947, 0.0, 0.0, -0.5153, -0.1719, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.5585, 0.7038, 0.0873, 0.0, -0.0338, 0.1456, 0.0873]
+      velocities: [0.0, 0.1396, -2.0504, 0.0, 0.0, -0.472, -0.1117, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 720000000
+    - 
+      positions: [0.0, 0.5479, 0.48, 0.0873, 0.0, -0.0787, 0.1396, 0.0873]
+      velocities: [0.0, -0.315, -2.2398, -0.0, 0.0, -0.4122, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 816000000
+    - 
+      positions: [0.0, 0.3805, 0.0969, 0.0873, 0.0, -0.1567, 0.1396, 0.0873]
+      velocities: [0.0, -0.6918, 0.0, 0.0, 0.0, -0.1655, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  80000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0873, 0.0, -0.1667, 0.1396, 0.0873]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+duration: 
+  secs: 1
+  nsecs: 199999999
+sounds: []

--- a/march_gait_files/airgait/walk/right_open/MIV_optimized_ankle_0.subgait
+++ b/march_gait_files/airgait/walk/right_open/MIV_optimized_ankle_0.subgait
@@ -1,0 +1,136 @@
+name: ''
+version: ''
+description: "The right open gait for the MIV walking gait."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  42600000
+    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 637400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 658100000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 765000000
+    joint_names: [right_hip_fe, left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 850000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 155999999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 530000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0, 0.0, -0.0873, 0.0, 0.0]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0824, 0.0094, 0.0, 0.0, -0.0879, 0.0005, 0.0]
+      velocities: [0.0, 0.2104, 0.4027, 0.0, 0.0, -0.0273, 0.0214, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  42600000
+    - 
+      positions: [0.0, 0.4954, 0.8692, 0.0, 0.0, -0.1605, 0.0799, 0.0]
+      velocities: [0.0, 0.795, 0.3394, 0.0, 0.0, -0.0912, 0.1797, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 637400000
+    - 
+      positions: [0.0, 0.5102, 0.8727, 0.0, 0.0, -0.1622, 0.0835, 0.0]
+      velocities: [0.0, 0.7168, 0.0, 0.0, 0.0, -0.0802, 0.1784, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 658100000
+    - 
+      positions: [0.0, 0.5585, 0.8409, 0.0, 0.0, -0.1667, 0.1024, 0.0]
+      velocities: [0.0, 0.1396, -0.5485, 0.0, 0.0, 0.0, 0.1633, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 765000000
+    - 
+      positions: [0.0, 0.565, 0.7811, 0.0, 0.0, -0.1667, 0.1147, 0.0]
+      velocities: [0.0, 0.0312, -0.8811, 0.0, 0.0, 0.0, 0.1439, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 850000000
+    - 
+      positions: [0.0, 0.5204, 0.4148, 0.0, 0.0, -0.1667, 0.1396, 0.0]
+      velocities: [0.0, -0.2832, -1.3187, 0.0, 0.0, -0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 155999999
+    - 
+      positions: [0.0, 0.3792, 0.0969, 0.0, 0.0, -0.1667, 0.1396, 0.0]
+      velocities: [0.0, -0.4006, 0.0, 0.0, 0.0, -0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 530000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0, 0.0, -0.1667, 0.1396, 0.0]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 700000000
+duration: 
+  secs: 1
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/airgait/walk/right_open/MIV_optimized_ankle_0_to_5.subgait
+++ b/march_gait_files/airgait/walk/right_open/MIV_optimized_ankle_0_to_5.subgait
@@ -1,0 +1,136 @@
+name: ''
+version: ''
+description: "The right open gait for the MIV walking gait."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee, right_ankle, left_hip_fe, left_knee, left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  42600000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 637400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 658100000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 765000000
+    joint_names: [right_hip_fe, left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 850000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 155999999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 530000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0, 0.0, -0.0873, 0.0, 0.0]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0824, 0.0094, 0.0001, 0.0, -0.0879, 0.0005, 0.0001]
+      velocities: [0.0, 0.2104, 0.4027, 0.0062, 0.0, -0.0273, 0.0214, 0.0062]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  42600000
+    - 
+      positions: [0.0, 0.4954, 0.8692, 0.0274, 0.0, -0.1605, 0.0799, 0.0274]
+      velocities: [0.0, 0.795, 0.3394, 0.0718, 0.0, -0.0912, 0.1797, 0.0718]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 637400000
+    - 
+      positions: [0.0, 0.5102, 0.8727, 0.0288, 0.0, -0.1622, 0.0835, 0.0288]
+      velocities: [0.0, 0.7168, 0.0, 0.0727, 0.0, -0.0802, 0.1784, 0.0727]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 658100000
+    - 
+      positions: [0.0, 0.5585, 0.8409, 0.0371, 0.0, -0.1667, 0.1024, 0.0371]
+      velocities: [0.0, 0.1396, -0.5485, 0.0762, 0.0, 0.0, 0.1633, 0.0762]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 765000000
+    - 
+      positions: [0.0, 0.565, 0.7811, 0.0433, 0.0, -0.1667, 0.1147, 0.0433]
+      velocities: [0.0, 0.0312, -0.8811, 0.077, 0.0, 0.0, 0.1439, 0.077]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 850000000
+    - 
+      positions: [0.0, 0.5204, 0.4148, 0.0656, 0.0, -0.1667, 0.1396, 0.0656]
+      velocities: [0.0, -0.2832, -1.3187, 0.068, 0.0, -0.0, 0.0, 0.068]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 155999999
+    - 
+      positions: [0.0, 0.3792, 0.0969, 0.0848, 0.0, -0.1667, 0.1396, 0.0848]
+      velocities: [0.0, -0.4006, 0.0, 0.0286, 0.0, -0.0, 0.0, 0.0286]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 530000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0873, 0.0, -0.1667, 0.1396, 0.0873]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 700000000
+duration: 
+  secs: 1
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/airgait/walk/right_open/MIV_optimized_ankle_2.5.subgait
+++ b/march_gait_files/airgait/walk/right_open/MIV_optimized_ankle_2.5.subgait
@@ -1,0 +1,136 @@
+name: ''
+version: ''
+description: "The right open gait for the MIV walking gait."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  42600000
+    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 637400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 658100000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 765000000
+    joint_names: [right_hip_fe, left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 850000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 155999999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 530000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0824, 0.0094, 0.0436, 0.0, -0.0879, 0.0005, 0.0436]
+      velocities: [0.0, 0.2104, 0.4027, 0.0, 0.0, -0.0273, 0.0214, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  42600000
+    - 
+      positions: [0.0, 0.4954, 0.8692, 0.0436, 0.0, -0.1605, 0.0799, 0.0436]
+      velocities: [0.0, 0.795, 0.3394, 0.0, 0.0, -0.0912, 0.1797, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 637400000
+    - 
+      positions: [0.0, 0.5102, 0.8727, 0.0436, 0.0, -0.1622, 0.0835, 0.0436]
+      velocities: [0.0, 0.7168, 0.0, 0.0, 0.0, -0.0802, 0.1784, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 658100000
+    - 
+      positions: [0.0, 0.5585, 0.8409, 0.0436, 0.0, -0.1667, 0.1024, 0.0436]
+      velocities: [0.0, 0.1396, -0.5485, 0.0, 0.0, 0.0, 0.1633, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 765000000
+    - 
+      positions: [0.0, 0.565, 0.7811, 0.0436, 0.0, -0.1667, 0.1147, 0.0436]
+      velocities: [0.0, 0.0312, -0.8811, 0.0, 0.0, 0.0, 0.1439, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 850000000
+    - 
+      positions: [0.0, 0.5204, 0.4148, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [0.0, -0.2832, -1.3187, 0.0, 0.0, -0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 155999999
+    - 
+      positions: [0.0, 0.3792, 0.0969, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [0.0, -0.4006, 0.0, 0.0, 0.0, -0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 530000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 700000000
+duration: 
+  secs: 1
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/airgait/walk/right_open/MIV_optimized_ankle_5.subgait
+++ b/march_gait_files/airgait/walk/right_open/MIV_optimized_ankle_5.subgait
@@ -1,0 +1,136 @@
+name: ''
+version: ''
+description: "The right open gait for the MIV walking gait."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  42600000
+    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 637400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 658100000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 765000000
+    joint_names: [right_hip_fe, left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 850000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 155999999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 530000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0873, 0.0, -0.0873, 0.0, 0.0873]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0824, 0.0094, 0.0873, 0.0, -0.0879, 0.0005, 0.0873]
+      velocities: [0.0, 0.2104, 0.4027, 0.0, 0.0, -0.0273, 0.0214, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  42600000
+    - 
+      positions: [0.0, 0.4954, 0.8692, 0.0873, 0.0, -0.1605, 0.0799, 0.0873]
+      velocities: [0.0, 0.795, 0.3394, 0.0, 0.0, -0.0912, 0.1797, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 637400000
+    - 
+      positions: [0.0, 0.5102, 0.8727, 0.0873, 0.0, -0.1622, 0.0835, 0.0873]
+      velocities: [0.0, 0.7168, 0.0, 0.0, 0.0, -0.0802, 0.1784, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 658100000
+    - 
+      positions: [0.0, 0.5585, 0.8409, 0.0873, 0.0, -0.1667, 0.1024, 0.0873]
+      velocities: [0.0, 0.1396, -0.5485, 0.0, 0.0, 0.0, 0.1633, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 765000000
+    - 
+      positions: [0.0, 0.565, 0.7811, 0.0873, 0.0, -0.1667, 0.1147, 0.0873]
+      velocities: [0.0, 0.0312, -0.8811, 0.0, 0.0, 0.0, 0.1439, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 850000000
+    - 
+      positions: [0.0, 0.5204, 0.4148, 0.0873, 0.0, -0.1667, 0.1396, 0.0873]
+      velocities: [0.0, -0.2832, -1.3187, 0.0, 0.0, -0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 155999999
+    - 
+      positions: [0.0, 0.3792, 0.0969, 0.0873, 0.0, -0.1667, 0.1396, 0.0873]
+      velocities: [0.0, -0.4006, 0.0, -0.0, 0.0, -0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 530000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0873, 0.0, -0.1667, 0.1396, 0.0873]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 700000000
+duration: 
+  secs: 1
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/airgait/walk/right_swing/MIV_1,1sec_ankle_0.subgait
+++ b/march_gait_files/airgait/walk/right_swing/MIV_1,1sec_ankle_0.subgait
@@ -1,0 +1,150 @@
+name: ''
+version: ''
+description: "The setpoints of this walking gait are the same as the setpoints of the MIII walking\
+  \ gait, except for the fact that the timing of the setpoints in different."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  27500000
+    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 220000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 412500000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 462000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 660000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 748000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 990000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 100000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0, 0.0, 0.3142, 0.1396, 0.0]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1648, 0.1437, 0.0, 0.0, 0.3069, 0.1413, 0.0]
+      velocities: [0.0, 0.1414, 0.3014, 0.0, 0.0, -0.3657, 0.1216, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  27500000
+    - 
+      positions: [0.0, 0.0031, 0.4609, 0.0, 0.0, 0.2193, 0.2094, 0.0]
+      velocities: [0.0, 1.3723, 2.3539, 0.0, 0.0, -0.5241, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 220000000
+    - 
+      positions: [0.0, 0.3019, 0.8406, 0.0, 0.0, 0.111, 0.1899, 0.0]
+      velocities: [0.0, 1.5609, 1.1265, 0.0, 0.0, -0.5867, -0.1775, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 412500000
+    - 
+      positions: [0.0, 0.3772, 0.8727, 0.0, 0.0, 0.0813, 0.1804, 0.0]
+      velocities: [0.0, 1.4374, 0.0, 0.0, 0.0, -0.5873, -0.1948, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 462000000
+    - 
+      positions: [0.0, 0.4891, 0.8213, 0.0, 0.0, 0.0286, 0.1626, 0.0]
+      velocities: [0.0, 1.0331, -1.1086, 0.0, 0.0, -0.5716, -0.1894, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [0.0, 0.5585, 0.6355, 0.0, 0.0, -0.0322, 0.1452, 0.0]
+      velocities: [0.0, 0.1396, -2.0254, 0.0, 0.0, -0.5232, -0.119, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 660000000
+    - 
+      positions: [0.0, 0.5463, 0.4391, 0.0, 0.0, -0.0767, 0.1396, 0.0]
+      velocities: [0.0, -0.3599, -2.1959, 0.0, 0.0, -0.4598, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 748000000
+    - 
+      positions: [0.0, 0.3776, 0.0969, 0.0, 0.0, -0.1565, 0.1396, 0.0]
+      velocities: [0.0, -0.745, 0.0, 0.0, 0.0, -0.1855, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 990000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0, 0.0, -0.1667, 0.1396, 0.0]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 100000000
+duration: 
+  secs: 1
+  nsecs: 100000000
+sounds: []

--- a/march_gait_files/airgait/walk/right_swing/MIV_1,1sec_ankle_2.5.subgait
+++ b/march_gait_files/airgait/walk/right_swing/MIV_1,1sec_ankle_2.5.subgait
@@ -1,0 +1,150 @@
+name: ''
+version: ''
+description: "The setpoints of this walking gait are the same as the setpoints of the MIII walking\
+  \ gait, except for the fact that the timing of the setpoints in different."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  27500000
+    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 220000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 412500000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 462000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 660000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 748000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 990000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 100000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1648, 0.1437, 0.0436, 0.0, 0.3069, 0.1413, 0.0436]
+      velocities: [0.0, 0.1414, 0.3014, 0.0, 0.0, -0.3657, 0.1216, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  27500000
+    - 
+      positions: [0.0, 0.0031, 0.4609, 0.0436, 0.0, 0.2193, 0.2094, 0.0436]
+      velocities: [0.0, 1.3723, 2.3539, 0.0, 0.0, -0.5241, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 220000000
+    - 
+      positions: [0.0, 0.3019, 0.8406, 0.0436, 0.0, 0.111, 0.1899, 0.0436]
+      velocities: [0.0, 1.5609, 1.1265, 0.0, 0.0, -0.5867, -0.1775, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 412500000
+    - 
+      positions: [0.0, 0.3772, 0.8727, 0.0436, 0.0, 0.0813, 0.1804, 0.0436]
+      velocities: [0.0, 1.4374, 0.0, 0.0, 0.0, -0.5873, -0.1948, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 462000000
+    - 
+      positions: [0.0, 0.4891, 0.8213, 0.0436, 0.0, 0.0286, 0.1626, 0.0436]
+      velocities: [0.0, 1.0331, -1.1086, -0.0, 0.0, -0.5716, -0.1894, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [0.0, 0.5585, 0.6355, 0.0436, 0.0, -0.0322, 0.1452, 0.0436]
+      velocities: [0.0, 0.1396, -2.0254, 0.0, 0.0, -0.5232, -0.119, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 660000000
+    - 
+      positions: [0.0, 0.5463, 0.4391, 0.0436, 0.0, -0.0767, 0.1396, 0.0436]
+      velocities: [0.0, -0.3599, -2.1959, 0.0, 0.0, -0.4598, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 748000000
+    - 
+      positions: [0.0, 0.3776, 0.0969, 0.0436, 0.0, -0.1565, 0.1396, 0.0436]
+      velocities: [0.0, -0.745, 0.0, 0.0, 0.0, -0.1855, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 990000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 100000000
+duration: 
+  secs: 1
+  nsecs: 100000000
+sounds: []

--- a/march_gait_files/airgait/walk/right_swing/MIV_1,1sec_ankle_5.subgait
+++ b/march_gait_files/airgait/walk/right_swing/MIV_1,1sec_ankle_5.subgait
@@ -1,0 +1,150 @@
+name: ''
+version: ''
+description: "The setpoints of this walking gait are the same as the setpoints of the MIII walking\
+  \ gait, except for the fact that the timing of the setpoints in different."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  27500000
+    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 220000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 412500000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 462000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 660000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 748000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 990000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 100000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0873, 0.0, 0.3142, 0.1396, 0.0873]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1648, 0.1437, 0.0873, 0.0, 0.3069, 0.1413, 0.0873]
+      velocities: [0.0, 0.1414, 0.3014, 0.0, 0.0, -0.3657, 0.1216, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  27500000
+    - 
+      positions: [0.0, 0.0031, 0.4609, 0.0873, 0.0, 0.2193, 0.2094, 0.0873]
+      velocities: [0.0, 1.3723, 2.3539, 0.0, 0.0, -0.5241, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 220000000
+    - 
+      positions: [0.0, 0.3019, 0.8406, 0.0873, 0.0, 0.111, 0.1899, 0.0873]
+      velocities: [0.0, 1.5609, 1.1265, 0.0, 0.0, -0.5867, -0.1775, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 412500000
+    - 
+      positions: [0.0, 0.3772, 0.8727, 0.0873, 0.0, 0.0813, 0.1804, 0.0873]
+      velocities: [0.0, 1.4374, 0.0, 0.0, 0.0, -0.5873, -0.1948, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 462000000
+    - 
+      positions: [0.0, 0.4891, 0.8213, 0.0873, 0.0, 0.0286, 0.1626, 0.0873]
+      velocities: [0.0, 1.0331, -1.1086, -0.0, 0.0, -0.5716, -0.1894, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [0.0, 0.5585, 0.6355, 0.0873, 0.0, -0.0322, 0.1452, 0.0873]
+      velocities: [0.0, 0.1396, -2.0254, 0.0, 0.0, -0.5232, -0.119, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 660000000
+    - 
+      positions: [0.0, 0.5463, 0.4391, 0.0873, 0.0, -0.0767, 0.1396, 0.0873]
+      velocities: [0.0, -0.3599, -2.1959, 0.0, 0.0, -0.4598, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 748000000
+    - 
+      positions: [0.0, 0.3776, 0.0969, 0.0873, 0.0, -0.1565, 0.1396, 0.0873]
+      velocities: [0.0, -0.745, 0.0, 0.0, 0.0, -0.1855, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 990000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0873, 0.0, -0.1667, 0.1396, 0.0873]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 100000000
+duration: 
+  secs: 1
+  nsecs: 100000000
+sounds: []

--- a/march_gait_files/airgait/walk/right_swing/MIV_more_knee_flexion_1,2sec_ankle_0.subgait
+++ b/march_gait_files/airgait/walk/right_swing/MIV_more_knee_flexion_1,2sec_ankle_0.subgait
@@ -1,0 +1,150 @@
+name: ''
+version: ''
+description: "The setpoints of this walking gait are the same as the setpoints of the MIII walking\
+  \ gait, except for the fact that the timing of the setpoints in different."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  30000000
+    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 240000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 450000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 504000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 720000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 816000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  80000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0, 0.0, 0.3142, 0.1396, 0.0]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1651, 0.1435, 0.0, 0.0, 0.3069, 0.141, 0.0]
+      velocities: [0.0, 0.1195, 0.2863, 0.0, 0.0, -0.3617, 0.1036, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  30000000
+    - 
+      positions: [0.0, 0.006, 0.5056, 0.0, 0.0, 0.2136, 0.2094, 0.0]
+      velocities: [0.0, 1.2637, 2.4204, 0.0, 0.0, -0.492, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 240000000
+    - 
+      positions: [0.0, 0.3107, 0.9312, 0.0, 0.0, 0.102, 0.1888, 0.0]
+      velocities: [0.0, 1.4182, 1.0477, 0.0, 0.0, -0.5363, -0.1657, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 450000000
+    - 
+      positions: [0.0, 0.3798, 0.9599, 0.0, 0.0, 0.0748, 0.1799, 0.0]
+      velocities: [0.0, 1.3091, 0.0, 0.0, 0.0, -0.5342, -0.1791, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 504000000
+    - 
+      positions: [0.0, 0.4931, 0.896, 0.0, 0.0, 0.0214, 0.1617, 0.0]
+      velocities: [0.0, 0.9226, -1.1947, 0.0, 0.0, -0.5153, -0.1719, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.5585, 0.7038, 0.0, 0.0, -0.0338, 0.1456, 0.0]
+      velocities: [0.0, 0.1396, -2.0504, 0.0, 0.0, -0.472, -0.1117, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 720000000
+    - 
+      positions: [0.0, 0.5479, 0.48, 0.0, 0.0, -0.0787, 0.1396, 0.0]
+      velocities: [0.0, -0.315, -2.2398, 0.0, 0.0, -0.4122, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 816000000
+    - 
+      positions: [0.0, 0.3805, 0.0969, 0.0, 0.0, -0.1567, 0.1396, 0.0]
+      velocities: [0.0, -0.6918, 0.0, 0.0, 0.0, -0.1655, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  80000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0, 0.0, -0.1667, 0.1396, 0.0]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+duration: 
+  secs: 1
+  nsecs: 199999999
+sounds: []

--- a/march_gait_files/airgait/walk/right_swing/MIV_more_knee_flexion_1,2sec_ankle_2.5.subgait
+++ b/march_gait_files/airgait/walk/right_swing/MIV_more_knee_flexion_1,2sec_ankle_2.5.subgait
@@ -1,0 +1,150 @@
+name: ''
+version: ''
+description: "The setpoints of this walking gait are the same as the setpoints of the MIII walking\
+  \ gait, except for the fact that the timing of the setpoints in different."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  30000000
+    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 240000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 450000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 504000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 720000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 816000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  80000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1651, 0.1435, 0.0436, 0.0, 0.3069, 0.141, 0.0436]
+      velocities: [0.0, 0.1195, 0.2863, 0.0, 0.0, -0.3617, 0.1036, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  30000000
+    - 
+      positions: [0.0, 0.006, 0.5056, 0.0436, 0.0, 0.2136, 0.2094, 0.0436]
+      velocities: [0.0, 1.2637, 2.4204, -0.0, 0.0, -0.492, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 240000000
+    - 
+      positions: [0.0, 0.3107, 0.9312, 0.0436, 0.0, 0.102, 0.1888, 0.0436]
+      velocities: [0.0, 1.4182, 1.0477, 0.0, 0.0, -0.5363, -0.1657, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 450000000
+    - 
+      positions: [0.0, 0.3798, 0.9599, 0.0436, 0.0, 0.0748, 0.1799, 0.0436]
+      velocities: [0.0, 1.3091, 0.0, 0.0, 0.0, -0.5342, -0.1791, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 504000000
+    - 
+      positions: [0.0, 0.4931, 0.896, 0.0436, 0.0, 0.0214, 0.1617, 0.0436]
+      velocities: [0.0, 0.9226, -1.1947, 0.0, 0.0, -0.5153, -0.1719, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.5585, 0.7038, 0.0436, 0.0, -0.0338, 0.1456, 0.0436]
+      velocities: [0.0, 0.1396, -2.0504, 0.0, 0.0, -0.472, -0.1117, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 720000000
+    - 
+      positions: [0.0, 0.5479, 0.48, 0.0436, 0.0, -0.0787, 0.1396, 0.0436]
+      velocities: [0.0, -0.315, -2.2398, 0.0, 0.0, -0.4122, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 816000000
+    - 
+      positions: [0.0, 0.3805, 0.0969, 0.0436, 0.0, -0.1567, 0.1396, 0.0436]
+      velocities: [0.0, -0.6918, 0.0, 0.0, 0.0, -0.1655, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  80000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+duration: 
+  secs: 1
+  nsecs: 199999999
+sounds: []

--- a/march_gait_files/airgait/walk/right_swing/MIV_more_knee_flexion_1,2sec_ankle_5.subgait
+++ b/march_gait_files/airgait/walk/right_swing/MIV_more_knee_flexion_1,2sec_ankle_5.subgait
@@ -1,0 +1,150 @@
+name: ''
+version: ''
+description: "The setpoints of this walking gait are the same as the setpoints of the MIII walking\
+  \ gait, except for the fact that the timing of the setpoints in different."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  30000000
+    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 240000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 450000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 504000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 720000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 816000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  80000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0873, 0.0, 0.3142, 0.1396, 0.0873]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1651, 0.1435, 0.0873, 0.0, 0.3069, 0.141, 0.0873]
+      velocities: [0.0, 0.1195, 0.2863, 0.0, 0.0, -0.3617, 0.1036, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  30000000
+    - 
+      positions: [0.0, 0.006, 0.5056, 0.0873, 0.0, 0.2136, 0.2094, 0.0873]
+      velocities: [0.0, 1.2637, 2.4204, -0.0, 0.0, -0.492, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 240000000
+    - 
+      positions: [0.0, 0.3107, 0.9312, 0.0873, 0.0, 0.102, 0.1888, 0.0873]
+      velocities: [0.0, 1.4182, 1.0477, -0.0, 0.0, -0.5363, -0.1657, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 450000000
+    - 
+      positions: [0.0, 0.3798, 0.9599, 0.0873, 0.0, 0.0748, 0.1799, 0.0873]
+      velocities: [0.0, 1.3091, 0.0, 0.0, 0.0, -0.5342, -0.1791, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 504000000
+    - 
+      positions: [0.0, 0.4931, 0.896, 0.0873, 0.0, 0.0214, 0.1617, 0.0873]
+      velocities: [0.0, 0.9226, -1.1947, 0.0, 0.0, -0.5153, -0.1719, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.5585, 0.7038, 0.0873, 0.0, -0.0338, 0.1456, 0.0873]
+      velocities: [0.0, 0.1396, -2.0504, 0.0, 0.0, -0.472, -0.1117, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 720000000
+    - 
+      positions: [0.0, 0.5479, 0.48, 0.0873, 0.0, -0.0787, 0.1396, 0.0873]
+      velocities: [0.0, -0.315, -2.2398, -0.0, 0.0, -0.4122, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 816000000
+    - 
+      positions: [0.0, 0.3805, 0.0969, 0.0873, 0.0, -0.1567, 0.1396, 0.0873]
+      velocities: [0.0, -0.6918, 0.0, 0.0, 0.0, -0.1655, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  80000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0873, 0.0, -0.1667, 0.1396, 0.0873]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+duration: 
+  secs: 1
+  nsecs: 199999999
+sounds: []


### PR DESCRIPTION
Add optimized walking gaits:
- Add a right_open version with earlier hip extension
- Add a left_swing and right_swing version with more knee flexion to have more foot clearance
- Add a faster version of the walking gait