### PR TITLE
Add new version of walking gait with larger step size

### DIFF
--- a/march_gait_files/airgait-v/walk/left_close/MV_walk_leftclose_v1.subgait
+++ b/march_gait_files/airgait-v/walk/left_close/MV_walk_leftclose_v1.subgait
@@ -1,0 +1,112 @@
+name: ''
+version: ''
+description: "The same gait as MIV, but with a somewhat larger step."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 496000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 581200000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 620000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 775000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 930000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 550000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1334, 0.1062, 0.0436]
+      velocities: [0.0, 1.2147, 0.0, 0.0, 0.0, -0.3259, -0.1166, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 496000000
+    - 
+      positions: [0.0, 0.5414, 0.8592, 0.0436, 0.0, 0.1088, 0.0964, 0.0436]
+      velocities: [0.0, 0.629, -0.3189, -0.0, 0.0, -0.2881, -0.1255, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 581200000
+    - 
+      positions: [0.0, 0.5585, 0.8424, 0.0436, 0.0, 0.0978, 0.0912, 0.0436]
+      velocities: [0.0, 0.1396, -0.4752, -0.0, 0.0, -0.2656, -0.1289, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 620000000
+    - 
+      positions: [0.0, 0.5257, 0.7216, 0.0436, 0.0, 0.0643, 0.0698, 0.0436]
+      velocities: [0.0, -0.503, -0.9556, -0.0, 0.0, -0.1515, -0.1351, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 775000000
+    - 
+      positions: [0.0, 0.414, 0.5555, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
+      velocities: [0.0, -0.9092, -1.1954, -0.0, 0.0, 0.0, -0.1303, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 930000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 550000000
+duration: 
+  secs: 1
+  nsecs: 550000000
+sounds: []

--- a/march_gait_files/airgait-v/walk/left_swing/MV_walk_leftswing_v1.subgait
+++ b/march_gait_files/airgait-v/walk/left_swing/MV_walk_leftswing_v1.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The same gait as MIV, but with a somewhat larger step."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 240000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 450000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 504000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 720000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 816000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  80000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.006, 0.4667, 0.0436, 0.0, 0.2136, 0.2094, 0.0436]
+      velocities: [0.0, 1.2637, 2.1631, 0.0, 0.0, -0.492, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 240000000
+    - 
+      positions: [0.0, 0.3107, 0.8471, 0.0436, 0.0, 0.102, 0.1888, 0.0436]
+      velocities: [0.0, 1.4182, 0.9364, 0.0, 0.0, -0.5363, -0.1657, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 450000000
+    - 
+      positions: [0.0, 0.3798, 0.8727, 0.0436, 0.0, 0.0748, 0.1799, 0.0436]
+      velocities: [0.0, 1.3091, 0.0, 0.0, 0.0, -0.5342, -0.1791, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 504000000
+    - 
+      positions: [0.0, 0.4931, 0.8152, 0.0436, 0.0, 0.0214, 0.1617, 0.0436]
+      velocities: [0.0, 0.9226, -1.074, 0.0, 0.0, -0.5153, -0.1719, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.5585, 0.6425, 0.0436, 0.0, -0.0338, 0.1456, 0.0436]
+      velocities: [0.0, 0.1396, -1.8432, 0.0, 0.0, -0.472, -0.1117, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 720000000
+    - 
+      positions: [0.0, 0.5479, 0.4413, 0.0436, 0.0, -0.0787, 0.1396, 0.0436]
+      velocities: [0.0, -0.315, -2.0135, 0.0, 0.0, -0.4122, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 816000000
+    - 
+      positions: [0.0, 0.3805, 0.0969, 0.0436, 0.0, -0.1567, 0.1396, 0.0436]
+      velocities: [0.0, -0.6918, 0.0, 0.0, 0.0, -0.1655, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  80000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+duration: 
+  secs: 1
+  nsecs: 199999999
+sounds: []

--- a/march_gait_files/airgait-v/walk/right_close/MV_walk_rightclose_v1.subgait
+++ b/march_gait_files/airgait-v/walk/right_close/MV_walk_rightclose_v1.subgait
@@ -1,0 +1,112 @@
+name: ''
+version: ''
+description: "The same gait as MIV, but with a somewhat larger step."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 496000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 581200000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 620000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 775000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 930000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 550000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1334, 0.1062, 0.0436]
+      velocities: [0.0, 1.2147, 0.0, 0.0, 0.0, -0.3259, -0.1166, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 496000000
+    - 
+      positions: [0.0, 0.5414, 0.8592, 0.0436, 0.0, 0.1088, 0.0964, 0.0436]
+      velocities: [0.0, 0.629, -0.3189, -0.0, 0.0, -0.2881, -0.1255, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 581200000
+    - 
+      positions: [0.0, 0.5585, 0.8424, 0.0436, 0.0, 0.0978, 0.0912, 0.0436]
+      velocities: [0.0, 0.1396, -0.4752, -0.0, 0.0, -0.2656, -0.1289, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 620000000
+    - 
+      positions: [0.0, 0.5257, 0.7216, 0.0436, 0.0, 0.0643, 0.0698, 0.0436]
+      velocities: [0.0, -0.503, -0.9556, -0.0, 0.0, -0.1515, -0.1351, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 775000000
+    - 
+      positions: [0.0, 0.414, 0.5555, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
+      velocities: [0.0, -0.9092, -1.1954, -0.0, 0.0, 0.0, -0.1303, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 930000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 550000000
+duration: 
+  secs: 1
+  nsecs: 550000000
+sounds: []

--- a/march_gait_files/airgait-v/walk/right_open/MV_walk_rightopen_v1.subgait
+++ b/march_gait_files/airgait-v/walk/right_open/MV_walk_rightopen_v1.subgait
@@ -1,0 +1,125 @@
+name: ''
+version: ''
+description: "The same gait as MIV, but with a somewhat larger step."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 562400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 750000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 900000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3269, 0.8374, 0.0436, 0.0, -0.1118, 0.0787, 0.0436]
+      velocities: [0.0, 1.01, 0.9344, -0.0, 0.0, -0.0737, 0.2041, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 562400000
+    - 
+      positions: [0.0, 0.3952, 0.8727, 0.0436, 0.0, -0.1171, 0.0928, 0.0436]
+      velocities: [0.0, 0.9304, 0.0, -0.0, 0.0, -0.077, 0.1959, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [0.0, 0.4928, 0.8197, 0.0436, 0.0, -0.1266, 0.1146, 0.0436]
+      velocities: [0.0, 0.683, -0.8363, 0.0, 0.0, -0.0794, 0.1636, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 750000000
+    - 
+      positions: [0.0, 0.5585, 0.6333, 0.0436, 0.0, -0.1384, 0.1339, 0.0436]
+      velocities: [0.0, 0.1396, -1.4938, 0.0, 0.0, -0.0766, 0.0907, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 900000000
+    - 
+      positions: [0.0, 0.5513, 0.4416, 0.0436, 0.0, -0.1473, 0.1396, 0.0436]
+      velocities: [0.0, -0.2264, -1.6102, 0.0, 0.0, -0.0697, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [0.0, 0.3863, 0.0969, 0.0436, 0.0, -0.1644, 0.1396, 0.0436]
+      velocities: [0.0, -0.5711, 0.0, 0.0, 0.0, -0.0296, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/walk/right_swing/MV_walk_rightswing_v1.subgait
+++ b/march_gait_files/airgait-v/walk/right_swing/MV_walk_rightswing_v1.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The same gait as MIV, but with a somewhat larger step."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 240000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 450000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 504000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 720000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 816000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  80000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.006, 0.4667, 0.0436, 0.0, 0.2136, 0.2094, 0.0436]
+      velocities: [0.0, 1.2637, 2.1631, 0.0, 0.0, -0.492, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 240000000
+    - 
+      positions: [0.0, 0.3107, 0.8471, 0.0436, 0.0, 0.102, 0.1888, 0.0436]
+      velocities: [0.0, 1.4182, 0.9364, 0.0, 0.0, -0.5363, -0.1657, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 450000000
+    - 
+      positions: [0.0, 0.3798, 0.8727, 0.0436, 0.0, 0.0748, 0.1799, 0.0436]
+      velocities: [0.0, 1.3091, 0.0, 0.0, 0.0, -0.5342, -0.1791, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 504000000
+    - 
+      positions: [0.0, 0.4931, 0.8152, 0.0436, 0.0, 0.0214, 0.1617, 0.0436]
+      velocities: [0.0, 0.9226, -1.074, 0.0, 0.0, -0.5153, -0.1719, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.5585, 0.6425, 0.0436, 0.0, -0.0338, 0.1456, 0.0436]
+      velocities: [0.0, 0.1396, -1.8432, 0.0, 0.0, -0.472, -0.1117, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 720000000
+    - 
+      positions: [0.0, 0.5479, 0.4413, 0.0436, 0.0, -0.0787, 0.1396, 0.0436]
+      velocities: [0.0, -0.315, -2.0135, 0.0, 0.0, -0.4122, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 816000000
+    - 
+      positions: [0.0, 0.3805, 0.0969, 0.0436, 0.0, -0.1567, 0.1396, 0.0436]
+      velocities: [0.0, -0.6918, 0.0, 0.0, 0.0, -0.1655, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  80000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+duration: 
+  secs: 1
+  nsecs: 199999999
+sounds: []

--- a/march_gait_files/test_versions-v/walk/left_close/MIV_final.subgait
+++ b/march_gait_files/test_versions-v/walk/left_close/MIV_final.subgait
@@ -1,0 +1,123 @@
+name: ''
+version: ''
+description: "Final left step of the MIV walking gait."
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_fe, left_knee, right_hip_fe, right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  38800000
+    joint_names: [left_hip_aa, left_ankle, right_hip_aa, right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 496000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 581200000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 620000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 775000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 930000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 550000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1619, 0.1474, 0.0436, 0.0, 0.2774, 0.1394, 0.0436]
+      velocities: [0.0, 0.2625, 0.4268, 0.0, 0.0, -0.3521, -0.0086, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  38800000
+    - 
+      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1215, 0.1062, 0.0436]
+      velocities: [0.0, 1.2147, 0.0, -0.0, 0.0, -0.2837, -0.1166, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 496000000
+    - 
+      positions: [0.0, 0.5414, 0.8592, 0.0436, 0.0, 0.1002, 0.0964, 0.0436]
+      velocities: [0.0, 0.629, -0.3189, 0.0, 0.0, -0.2479, -0.1255, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 581200000
+    - 
+      positions: [0.0, 0.5585, 0.8424, 0.0436, 0.0, 0.0908, 0.0912, 0.0436]
+      velocities: [0.0, 0.1396, -0.4752, 0.0, 0.0, -0.2274, -0.1289, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 620000000
+    - 
+      positions: [0.0, 0.5257, 0.7216, 0.0436, 0.0, 0.0623, 0.0698, 0.0436]
+      velocities: [0.0, -0.503, -0.9556, -0.0, 0.0, -0.1274, -0.1351, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 775000000
+    - 
+      positions: [0.0, 0.414, 0.5555, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
+      velocities: [0.0, -0.9092, -1.1954, 0.0, 0.0, 0.0, -0.1303, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 930000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 550000000
+duration: 
+  secs: 1
+  nsecs: 550000000
+sounds: []

--- a/march_gait_files/test_versions-v/walk/left_close/MV_walk_leftclose_v1.subgait
+++ b/march_gait_files/test_versions-v/walk/left_close/MV_walk_leftclose_v1.subgait
@@ -1,0 +1,112 @@
+name: ''
+version: ''
+description: "The same gait as MIV, but with a somewhat larger step."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 496000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 581200000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 620000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 775000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 930000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 550000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1334, 0.1062, 0.0436]
+      velocities: [0.0, 1.2147, 0.0, 0.0, 0.0, -0.3259, -0.1166, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 496000000
+    - 
+      positions: [0.0, 0.5414, 0.8592, 0.0436, 0.0, 0.1088, 0.0964, 0.0436]
+      velocities: [0.0, 0.629, -0.3189, -0.0, 0.0, -0.2881, -0.1255, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 581200000
+    - 
+      positions: [0.0, 0.5585, 0.8424, 0.0436, 0.0, 0.0978, 0.0912, 0.0436]
+      velocities: [0.0, 0.1396, -0.4752, -0.0, 0.0, -0.2656, -0.1289, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 620000000
+    - 
+      positions: [0.0, 0.5257, 0.7216, 0.0436, 0.0, 0.0643, 0.0698, 0.0436]
+      velocities: [0.0, -0.503, -0.9556, -0.0, 0.0, -0.1515, -0.1351, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 775000000
+    - 
+      positions: [0.0, 0.414, 0.5555, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
+      velocities: [0.0, -0.9092, -1.1954, -0.0, 0.0, 0.0, -0.1303, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 930000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 550000000
+duration: 
+  secs: 1
+  nsecs: 550000000
+sounds: []

--- a/march_gait_files/test_versions-v/walk/left_swing/MIV_final.subgait
+++ b/march_gait_files/test_versions-v/walk/left_swing/MIV_final.subgait
@@ -1,0 +1,150 @@
+name: ''
+version: ''
+description: "The setpoints of this walking gait are the same as the setpoints of the MIV, but\
+  \ less flexion of the hip"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_fe, left_knee, right_hip_fe, right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  30000000
+    joint_names: [left_hip_aa, left_ankle, right_hip_aa, right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 240000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 450000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 504000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 720000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 816000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  80000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1652, 0.1431, 0.0436, 0.0, 0.2808, 0.141, 0.0436]
+      velocities: [0.0, 0.1075, 0.2559, 0.0, 0.0, -0.36, 0.1036, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  30000000
+    - 
+      positions: [0.0, -0.0113, 0.4667, 0.0436, 0.0, 0.19, 0.2094, 0.0436]
+      velocities: [0.0, 1.1376, 2.1631, -0.0, 0.0, -0.4718, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 240000000
+    - 
+      positions: [0.0, 0.2634, 0.8471, 0.0436, 0.0, 0.0841, 0.1888, 0.0436]
+      velocities: [0.0, 1.2804, 0.9364, 0.0, 0.0, -0.5058, -0.1657, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 450000000
+    - 
+      positions: [0.0, 0.3257, 0.8727, 0.0436, 0.0, 0.0584, 0.1799, 0.0436]
+      velocities: [0.0, 1.1836, 0.0, 0.0, 0.0, -0.5024, -0.1791, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 504000000
+    - 
+      positions: [0.0, 0.4285, 0.8152, 0.0436, 0.0, 0.0083, 0.1617, 0.0436]
+      velocities: [0.0, 0.8392, -1.074, 0.0, 0.0, -0.4825, -0.1719, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.4887, 0.6425, 0.0436, 0.0, -0.0433, 0.1456, 0.0436]
+      velocities: [0.0, 0.1396, -1.8432, 0.0, 0.0, -0.4403, -0.1117, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 720000000
+    - 
+      positions: [0.0, 0.4824, 0.4413, 0.0436, 0.0, -0.0851, 0.1396, 0.0436]
+      velocities: [0.0, -0.2331, -2.0135, 0.0, 0.0, -0.3834, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 816000000
+    - 
+      positions: [0.0, 0.3472, 0.0969, 0.0436, 0.0, -0.1574, 0.1396, 0.0436]
+      velocities: [0.0, -0.5857, 0.0, 0.0, 0.0, -0.1531, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  80000000
+    - 
+      positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+duration: 
+  secs: 1
+  nsecs: 199999999
+sounds: []

--- a/march_gait_files/test_versions-v/walk/left_swing/MV_walk_leftswing_v1.subgait
+++ b/march_gait_files/test_versions-v/walk/left_swing/MV_walk_leftswing_v1.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The same gait as MIV, but with a somewhat larger step."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 240000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 450000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 504000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 720000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 816000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  80000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.006, 0.4667, 0.0436, 0.0, 0.2136, 0.2094, 0.0436]
+      velocities: [0.0, 1.2637, 2.1631, 0.0, 0.0, -0.492, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 240000000
+    - 
+      positions: [0.0, 0.3107, 0.8471, 0.0436, 0.0, 0.102, 0.1888, 0.0436]
+      velocities: [0.0, 1.4182, 0.9364, 0.0, 0.0, -0.5363, -0.1657, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 450000000
+    - 
+      positions: [0.0, 0.3798, 0.8727, 0.0436, 0.0, 0.0748, 0.1799, 0.0436]
+      velocities: [0.0, 1.3091, 0.0, 0.0, 0.0, -0.5342, -0.1791, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 504000000
+    - 
+      positions: [0.0, 0.4931, 0.8152, 0.0436, 0.0, 0.0214, 0.1617, 0.0436]
+      velocities: [0.0, 0.9226, -1.074, 0.0, 0.0, -0.5153, -0.1719, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.5585, 0.6425, 0.0436, 0.0, -0.0338, 0.1456, 0.0436]
+      velocities: [0.0, 0.1396, -1.8432, 0.0, 0.0, -0.472, -0.1117, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 720000000
+    - 
+      positions: [0.0, 0.5479, 0.4413, 0.0436, 0.0, -0.0787, 0.1396, 0.0436]
+      velocities: [0.0, -0.315, -2.0135, 0.0, 0.0, -0.4122, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 816000000
+    - 
+      positions: [0.0, 0.3805, 0.0969, 0.0436, 0.0, -0.1567, 0.1396, 0.0436]
+      velocities: [0.0, -0.6918, 0.0, 0.0, 0.0, -0.1655, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  80000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+duration: 
+  secs: 1
+  nsecs: 199999999
+sounds: []

--- a/march_gait_files/test_versions-v/walk/right_close/MIV_final.subgait
+++ b/march_gait_files/test_versions-v/walk/right_close/MIV_final.subgait
@@ -1,0 +1,123 @@
+name: ''
+version: ''
+description: "Final right step of the MIV walking gait with less hip flexion"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  38800000
+    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 496000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 581200000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 620000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 775000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 930000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 550000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1619, 0.1474, 0.0436, 0.0, 0.2774, 0.1394, 0.0436]
+      velocities: [0.0, 0.2625, 0.4268, 0.0, 0.0, -0.3521, -0.0086, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  38800000
+    - 
+      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1215, 0.1062, 0.0436]
+      velocities: [0.0, 1.2147, 0.0, -0.0, 0.0, -0.2837, -0.1166, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 496000000
+    - 
+      positions: [0.0, 0.5414, 0.8592, 0.0436, 0.0, 0.1002, 0.0964, 0.0436]
+      velocities: [0.0, 0.629, -0.3189, 0.0, 0.0, -0.2479, -0.1255, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 581200000
+    - 
+      positions: [0.0, 0.5585, 0.8424, 0.0436, 0.0, 0.0908, 0.0912, 0.0436]
+      velocities: [0.0, 0.1396, -0.4752, 0.0, 0.0, -0.2274, -0.1289, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 620000000
+    - 
+      positions: [0.0, 0.5257, 0.7216, 0.0436, 0.0, 0.0623, 0.0698, 0.0436]
+      velocities: [0.0, -0.503, -0.9556, -0.0, 0.0, -0.1274, -0.1351, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 775000000
+    - 
+      positions: [0.0, 0.414, 0.5555, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
+      velocities: [0.0, -0.9092, -1.1954, 0.0, 0.0, 0.0, -0.1303, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 930000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 550000000
+duration: 
+  secs: 1
+  nsecs: 550000000
+sounds: []

--- a/march_gait_files/test_versions-v/walk/right_close/MV_walk_rightclose_v1.subgait
+++ b/march_gait_files/test_versions-v/walk/right_close/MV_walk_rightclose_v1.subgait
@@ -1,0 +1,112 @@
+name: ''
+version: ''
+description: "The same gait as MIV, but with a somewhat larger step."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 496000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 581200000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 620000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 775000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 930000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 550000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1334, 0.1062, 0.0436]
+      velocities: [0.0, 1.2147, 0.0, 0.0, 0.0, -0.3259, -0.1166, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 496000000
+    - 
+      positions: [0.0, 0.5414, 0.8592, 0.0436, 0.0, 0.1088, 0.0964, 0.0436]
+      velocities: [0.0, 0.629, -0.3189, -0.0, 0.0, -0.2881, -0.1255, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 581200000
+    - 
+      positions: [0.0, 0.5585, 0.8424, 0.0436, 0.0, 0.0978, 0.0912, 0.0436]
+      velocities: [0.0, 0.1396, -0.4752, -0.0, 0.0, -0.2656, -0.1289, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 620000000
+    - 
+      positions: [0.0, 0.5257, 0.7216, 0.0436, 0.0, 0.0643, 0.0698, 0.0436]
+      velocities: [0.0, -0.503, -0.9556, -0.0, 0.0, -0.1515, -0.1351, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 775000000
+    - 
+      positions: [0.0, 0.414, 0.5555, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
+      velocities: [0.0, -0.9092, -1.1954, -0.0, 0.0, 0.0, -0.1303, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 930000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 550000000
+duration: 
+  secs: 1
+  nsecs: 550000000
+sounds: []

--- a/march_gait_files/test_versions-v/walk/right_open/MIV_final.subgait
+++ b/march_gait_files/test_versions-v/walk/right_open/MIV_final.subgait
@@ -1,0 +1,136 @@
+name: ''
+version: ''
+description: "The right open gait for the MIV walking gait with less hip flexion"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  37600000
+    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 562400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 750000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 900000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0855, 0.0058, 0.0436, 0.0, -0.0874, 0.0004, 0.0436]
+      velocities: [0.0, 0.0969, 0.3186, 0.0, 0.0, -0.0052, 0.0198, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  37600000
+    - 
+      positions: [0.0, 0.2802, 0.8374, 0.0436, 0.0, -0.1118, 0.0787, 0.0436]
+      velocities: [0.0, 0.8993, 0.9344, -0.0, 0.0, -0.0737, 0.2041, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 562400000
+    - 
+      positions: [0.0, 0.341, 0.8727, 0.0436, 0.0, -0.1171, 0.0928, 0.0436]
+      velocities: [0.0, 0.8305, 0.0, -0.0, 0.0, -0.077, 0.1959, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [0.0, 0.4285, 0.8197, 0.0436, 0.0, -0.1266, 0.1146, 0.0436]
+      velocities: [0.0, 0.615, -0.8363, -0.0, 0.0, -0.0794, 0.1636, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 750000000
+    - 
+      positions: [0.0, 0.4887, 0.6333, 0.0436, 0.0, -0.1384, 0.1339, 0.0436]
+      velocities: [0.0, 0.1396, -1.4938, 0.0, 0.0, -0.0766, 0.0907, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 900000000
+    - 
+      positions: [0.0, 0.4858, 0.4416, 0.0436, 0.0, -0.1473, 0.1396, 0.0436]
+      velocities: [0.0, -0.1603, -1.6102, 0.0, 0.0, -0.0697, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [0.0, 0.3532, 0.0969, 0.0436, 0.0, -0.1644, 0.1396, 0.0436]
+      velocities: [0.0, -0.4872, 0.0, 0.0, 0.0, -0.0296, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/test_versions-v/walk/right_open/MV_walk_rightopen_v1.subgait
+++ b/march_gait_files/test_versions-v/walk/right_open/MV_walk_rightopen_v1.subgait
@@ -1,0 +1,125 @@
+name: ''
+version: ''
+description: "The same gait as MIV, but with a somewhat larger step."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 562400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 750000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 900000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3269, 0.8374, 0.0436, 0.0, -0.1118, 0.0787, 0.0436]
+      velocities: [0.0, 1.01, 0.9344, -0.0, 0.0, -0.0737, 0.2041, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 562400000
+    - 
+      positions: [0.0, 0.3952, 0.8727, 0.0436, 0.0, -0.1171, 0.0928, 0.0436]
+      velocities: [0.0, 0.9304, 0.0, -0.0, 0.0, -0.077, 0.1959, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [0.0, 0.4928, 0.8197, 0.0436, 0.0, -0.1266, 0.1146, 0.0436]
+      velocities: [0.0, 0.683, -0.8363, 0.0, 0.0, -0.0794, 0.1636, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 750000000
+    - 
+      positions: [0.0, 0.5585, 0.6333, 0.0436, 0.0, -0.1384, 0.1339, 0.0436]
+      velocities: [0.0, 0.1396, -1.4938, 0.0, 0.0, -0.0766, 0.0907, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 900000000
+    - 
+      positions: [0.0, 0.5513, 0.4416, 0.0436, 0.0, -0.1473, 0.1396, 0.0436]
+      velocities: [0.0, -0.2264, -1.6102, 0.0, 0.0, -0.0697, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [0.0, 0.3863, 0.0969, 0.0436, 0.0, -0.1644, 0.1396, 0.0436]
+      velocities: [0.0, -0.5711, 0.0, 0.0, 0.0, -0.0296, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/test_versions-v/walk/right_swing/MIV_final.subgait
+++ b/march_gait_files/test_versions-v/walk/right_swing/MIV_final.subgait
@@ -1,0 +1,150 @@
+name: ''
+version: ''
+description: "The setpoints of this walking gait are the same as the setpoints of the MIV, but\
+  \ less flexion of the hip"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:  30000000
+    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 240000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 450000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 504000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 720000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 816000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  80000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1652, 0.1431, 0.0436, 0.0, 0.2808, 0.141, 0.0436]
+      velocities: [0.0, 0.1075, 0.2559, 0.0, 0.0, -0.36, 0.1036, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:  30000000
+    - 
+      positions: [0.0, -0.0113, 0.4667, 0.0436, 0.0, 0.19, 0.2094, 0.0436]
+      velocities: [0.0, 1.1376, 2.1631, -0.0, 0.0, -0.4718, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 240000000
+    - 
+      positions: [0.0, 0.2634, 0.8471, 0.0436, 0.0, 0.0841, 0.1888, 0.0436]
+      velocities: [0.0, 1.2804, 0.9364, 0.0, 0.0, -0.5058, -0.1657, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 450000000
+    - 
+      positions: [0.0, 0.3257, 0.8727, 0.0436, 0.0, 0.0584, 0.1799, 0.0436]
+      velocities: [0.0, 1.1836, 0.0, 0.0, 0.0, -0.5024, -0.1791, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 504000000
+    - 
+      positions: [0.0, 0.4285, 0.8152, 0.0436, 0.0, 0.0083, 0.1617, 0.0436]
+      velocities: [0.0, 0.8392, -1.074, 0.0, 0.0, -0.4825, -0.1719, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.4887, 0.6425, 0.0436, 0.0, -0.0433, 0.1456, 0.0436]
+      velocities: [0.0, 0.1396, -1.8432, 0.0, 0.0, -0.4403, -0.1117, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 720000000
+    - 
+      positions: [0.0, 0.4824, 0.4413, 0.0436, 0.0, -0.0851, 0.1396, 0.0436]
+      velocities: [0.0, -0.2331, -2.0135, 0.0, 0.0, -0.3834, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 816000000
+    - 
+      positions: [0.0, 0.3472, 0.0969, 0.0436, 0.0, -0.1574, 0.1396, 0.0436]
+      velocities: [0.0, -0.5857, 0.0, 0.0, 0.0, -0.1531, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  80000000
+    - 
+      positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+duration: 
+  secs: 1
+  nsecs: 199999999
+sounds: []

--- a/march_gait_files/test_versions-v/walk/right_swing/MV_walk_rightswing_v1.subgait
+++ b/march_gait_files/test_versions-v/walk/right_swing/MV_walk_rightswing_v1.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The same gait as MIV, but with a somewhat larger step."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 240000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 450000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 504000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 720000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 816000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  80000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.006, 0.4667, 0.0436, 0.0, 0.2136, 0.2094, 0.0436]
+      velocities: [0.0, 1.2637, 2.1631, 0.0, 0.0, -0.492, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 240000000
+    - 
+      positions: [0.0, 0.3107, 0.8471, 0.0436, 0.0, 0.102, 0.1888, 0.0436]
+      velocities: [0.0, 1.4182, 0.9364, 0.0, 0.0, -0.5363, -0.1657, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 450000000
+    - 
+      positions: [0.0, 0.3798, 0.8727, 0.0436, 0.0, 0.0748, 0.1799, 0.0436]
+      velocities: [0.0, 1.3091, 0.0, 0.0, 0.0, -0.5342, -0.1791, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 504000000
+    - 
+      positions: [0.0, 0.4931, 0.8152, 0.0436, 0.0, 0.0214, 0.1617, 0.0436]
+      velocities: [0.0, 0.9226, -1.074, 0.0, 0.0, -0.5153, -0.1719, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.5585, 0.6425, 0.0436, 0.0, -0.0338, 0.1456, 0.0436]
+      velocities: [0.0, 0.1396, -1.8432, 0.0, 0.0, -0.472, -0.1117, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 720000000
+    - 
+      positions: [0.0, 0.5479, 0.4413, 0.0436, 0.0, -0.0787, 0.1396, 0.0436]
+      velocities: [0.0, -0.315, -2.0135, 0.0, 0.0, -0.4122, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 816000000
+    - 
+      positions: [0.0, 0.3805, 0.0969, 0.0436, 0.0, -0.1567, 0.1396, 0.0436]
+      velocities: [0.0, -0.6918, 0.0, 0.0, 0.0, -0.1655, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  80000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+duration: 
+  secs: 1
+  nsecs: 199999999
+sounds: []

--- a/march_gait_files/test_versions-v/walk/walk.gait
+++ b/march_gait_files/test_versions-v/walk/walk.gait
@@ -1,0 +1,5 @@
+name: walk
+
+graph:
+  from_subgait: [start,     right_open, left_swing, right_swing, left_close, start, right_open, left_swing, right_close]
+  to_subgait:   [right_open, left_swing, right_swing, left_close, end, right_open, left_swing, right_close, end]


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
--> Add a new version of the walking gait that has a larger step size. Sjaan has indicated during the last training that she wants to try this, so I thought it would be nice if we have a version for the next training ready. In this version, only the hip flexion angles are adjusted - based on an earlier gait made by MARCH IV that had somewhat larger steps - nothing else has changed in the gait, as I think it is better to do this later, when we have analysed the gait and know how to change it. Also, I copied the (sub)gait files to the airgait-v folder.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
--> Added a new version of the walking gait.

<!-- Please don't forget to request for reviews -->
