### PR TITLE
Fix left leg of Rough Terrain high step

### DIFF
--- a/march_gait_files/airgait-v/default.yaml
+++ b/march_gait_files/airgait-v/default.yaml
@@ -7,7 +7,7 @@ gaits:
                          right_swing: MV_RD_slopedown_rightswing_v1, left_swing: MV_RD_slopedown_leftswing_v1,
                          right_close: MV_RD_slopedown_rightclose_v1, left_close: MV_RD_slopedown_leftclose_v1}
   ramp_door_last_step: {right_open: MV_RD_laststep_rightopen_v2, left_close: MV_RD_laststep_leftclose_v2}
-  rough_terrain_high_step: {right_open: MV_RT_highstep_rightopen_v5, left_close: MV_RT_highstep_leftclose_v6}
+  rough_terrain_high_step: {right_open: MV_RT_highstep_rightopen_v6, left_close: MV_RT_highstep_leftclose_v7}
   rough_terrain_middle_steps: {right_open: MV_RT_middlestep_rightopen_v2, left_swing: MV_RT_middlestep_leftswing_v2,
                                right_swing: MV_RT_middlestep_rightswing_v2, left_close: MV_RT_middlestep_leftclose_v3}
   walk: {right_open: MV_walk_rightopen_v2, left_swing: MV_walk_leftswing_v2, right_swing: MV_walk_rightswing_v2,

--- a/march_gait_files/airgait-v/rough_terrain_high_step/left_close/MV_RT_highstep_leftclose_v7.subgait
+++ b/march_gait_files/airgait-v/rough_terrain_high_step/left_close/MV_RT_highstep_leftclose_v7.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "Added a little more knee flexion at the beginning."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 619100000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 873600000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  12399999
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  57600000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 336500000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  54100000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.3491, 0.1396, 0.0436, 0.0, -0.2269, 0.3491, 0.0436]
+      velocities: [0.0, -0.3491, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.1642, 0.1396, 0.0436, 0.0, 0.1537, 1.0221, 0.0436]
+      velocities: [0.0, -0.2571, 0.0, 0.0, 0.0, 1.9984, 1.512, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 619100000
+    - 
+      positions: [0.0, 0.1021, 0.1396, 0.0436, 0.0, 0.5903, 1.3514, 0.0436]
+      velocities: [0.0, -0.2199, 0.0, -0.0, 0.0, 1.4188, 0.9091, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 873600000
+    - 
+      positions: [0.0, 0.0747, 0.1376, 0.0436, 0.0, 0.7494, 1.431, 0.0436]
+      velocities: [0.0, -0.2019, -0.0293, -0.0, 0.0, 1.0409, 0.3252, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  12399999
+    - 
+      positions: [0.0, 0.0648, 0.1358, 0.0436, 0.0, 0.7969, 1.4392, 0.0436]
+      velocities: [0.0, -0.1951, -0.0398, 0.0, 0.0, 0.882, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  57600000
+    - 
+      positions: [0.0, 0.0154, 0.1174, 0.0436, 0.0, 0.9002, 1.3299, 0.0436]
+      velocities: [0.0, -0.1578, -0.086, 0.0, 0.0, -0.1745, -0.7272, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 336500000
+    - 
+      positions: [0.0, 0.0139, 0.1165, 0.0436, 0.0, 0.8986, 1.3224, 0.0436]
+      velocities: [0.0, -0.1565, -0.0872, -0.0, 0.0, -0.1857, -0.7485, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, -0.0649, 0.0407, 0.0436, 0.0, 0.2842, 0.5009, 0.0436]
+      velocities: [0.0, -0.0707, -0.1057, 0.0, 0.0, -1.0447, -1.2621, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  54100000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 700000000
+duration: 
+  secs: 2
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/airgait-v/rough_terrain_high_step/right_open/MV_RT_highstep_rightopen_v6.subgait
+++ b/march_gait_files/airgait-v/rough_terrain_high_step/right_open/MV_RT_highstep_rightopen_v6.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "Added a little more knee flexion in the left knee."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 619100000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  12399999
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 176500000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 336500000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 836000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 466200000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.1537, 0.7636, 0.0436, 0.0, -0.1056, 0.0362, 0.0436]
+      velocities: [0.0, 2.0, 1.833, 0.0, 0.0, -0.0541, 0.101, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 619100000
+    - 
+      positions: [0.0, 0.7495, 1.3552, 0.0436, 0.0, -0.1308, 0.0795, 0.0436]
+      velocities: [0.0, 1.0405, 0.9416, -0.0, 0.0, -0.0723, 0.1132, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  12399999
+    - 
+      positions: [0.0, 0.8767, 1.4392, 0.0436, 0.0, -0.1436, 0.0983, 0.0436]
+      velocities: [0.0, 0.4692, 0.0, 0.0, 0.0, -0.0762, 0.1055, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 176500000
+    - 
+      positions: [0.0, 0.9002, 1.3852, 0.0436, 0.0, -0.1559, 0.1141, 0.0436]
+      velocities: [0.0, -0.1745, -0.6337, 0.0, 0.0, -0.0775, 0.0911, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 336500000
+    - 
+      positions: [0.0, 0.8987, 1.3785, 0.0436, 0.0, -0.1567, 0.115, 0.0436]
+      velocities: [0.0, -0.1767, -0.6692, -0.0, 0.0, -0.0776, 0.09, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, 0.742, 0.7812, 0.0436, 0.0, -0.1925, 0.1396, 0.0436]
+      velocities: [0.0, -0.4325, -1.5115, 0.0, 0.0, -0.0681, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 836000000
+    - 
+      positions: [0.0, 0.4455, 0.1396, 0.0436, 0.0, -0.2238, 0.3093, 0.0436]
+      velocities: [0.0, -0.4439, 0.0, 0.0, 0.0, -0.0257, 0.2962, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 466200000
+    - 
+      positions: [0.0, 0.3491, 0.1396, 0.0436, 0.0, -0.2269, 0.3491, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 700000000
+duration: 
+  secs: 2
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/test_versions-v/default.yaml
+++ b/march_gait_files/test_versions-v/default.yaml
@@ -7,7 +7,7 @@ gaits:
                          right_swing: MV_RD_slopedown_rightswing_v1, left_swing: MV_RD_slopedown_leftswing_v1,
                          right_close: MV_RD_slopedown_rightclose_v1, left_close: MV_RD_slopedown_leftclose_v1}
   ramp_door_last_step: {right_open: MV_RD_laststep_rightopen_v2, left_close: MV_RD_laststep_leftclose_v2}
-  rough_terrain_high_step: {right_open: MV_RT_highstep_rightopen_v4, left_close: MV_RT_highstep_leftclose_v5}
+  rough_terrain_high_step: {right_open: MV_RT_highstep_rightopen_v6, left_close: MV_RT_highstep_leftclose_v7}
   rough_terrain_middle_steps: {right_open: MV_RT_middlestep_rightopen_v2, left_swing: MV_RT_middlestep_leftswing_v2,
                                right_swing: MV_RT_middlestep_rightswing_v2, left_close: MV_RT_middlestep_leftclose_v3}
   walk: {right_open: MV_walk_rightopen_v2, left_swing: MV_walk_leftswing_v2, right_swing: MV_walk_rightswing_v2,

--- a/march_gait_files/test_versions-v/rough_terrain_high_step/left_close/MV_RT_highstep_leftclose_v6.subgait
+++ b/march_gait_files/test_versions-v/rough_terrain_high_step/left_close/MV_RT_highstep_leftclose_v6.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "Removed ankle from gait."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 619100000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 873600000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  12399999
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  57600000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 336500000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  54100000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.3491, 0.1396, 0.0436, 0.0, -0.2269, 0.1396, 0.0436]
+      velocities: [0.0, -0.3491, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.1642, 0.1396, 0.0436, 0.0, 0.1537, 0.942, 0.0436]
+      velocities: [0.0, -0.2571, 0.0, 0.0, 0.0, 1.9984, 1.8026, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 619100000
+    - 
+      positions: [0.0, 0.1021, 0.1396, 0.0436, 0.0, 0.5903, 1.3345, 0.0436]
+      velocities: [0.0, -0.2199, 0.0, -0.0, 0.0, 1.4188, 1.0838, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 873600000
+    - 
+      positions: [0.0, 0.0747, 0.1376, 0.0436, 0.0, 0.7494, 1.4294, 0.0436]
+      velocities: [0.0, -0.2019, -0.0293, -0.0, 0.0, 1.0409, 0.3877, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  12399999
+    - 
+      positions: [0.0, 0.0648, 0.1358, 0.0436, 0.0, 0.7969, 1.4392, 0.0436]
+      velocities: [0.0, -0.1951, -0.0398, 0.0, 0.0, 0.882, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  57600000
+    - 
+      positions: [0.0, 0.0154, 0.1174, 0.0436, 0.0, 0.9002, 1.3299, 0.0436]
+      velocities: [0.0, -0.1578, -0.086, 0.0, 0.0, -0.1745, -0.7272, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 336500000
+    - 
+      positions: [0.0, 0.0139, 0.1165, 0.0436, 0.0, 0.8986, 1.3224, 0.0436]
+      velocities: [0.0, -0.1565, -0.0872, -0.0, 0.0, -0.1857, -0.7485, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, -0.0649, 0.0407, 0.0436, 0.0, 0.2842, 0.5009, 0.0436]
+      velocities: [0.0, -0.0707, -0.1057, 0.0, 0.0, -1.0447, -1.2621, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  54100000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 700000000
+duration: 
+  secs: 2
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/test_versions-v/rough_terrain_high_step/left_close/MV_RT_highstep_leftclose_v7.subgait
+++ b/march_gait_files/test_versions-v/rough_terrain_high_step/left_close/MV_RT_highstep_leftclose_v7.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "Added a little more knee flexion at the beginning."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 619100000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 873600000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  12399999
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  57600000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 336500000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  54100000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.3491, 0.1396, 0.0436, 0.0, -0.2269, 0.3491, 0.0436]
+      velocities: [0.0, -0.3491, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.1642, 0.1396, 0.0436, 0.0, 0.1537, 1.0221, 0.0436]
+      velocities: [0.0, -0.2571, 0.0, 0.0, 0.0, 1.9984, 1.512, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 619100000
+    - 
+      positions: [0.0, 0.1021, 0.1396, 0.0436, 0.0, 0.5903, 1.3514, 0.0436]
+      velocities: [0.0, -0.2199, 0.0, -0.0, 0.0, 1.4188, 0.9091, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 873600000
+    - 
+      positions: [0.0, 0.0747, 0.1376, 0.0436, 0.0, 0.7494, 1.431, 0.0436]
+      velocities: [0.0, -0.2019, -0.0293, -0.0, 0.0, 1.0409, 0.3252, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  12399999
+    - 
+      positions: [0.0, 0.0648, 0.1358, 0.0436, 0.0, 0.7969, 1.4392, 0.0436]
+      velocities: [0.0, -0.1951, -0.0398, 0.0, 0.0, 0.882, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  57600000
+    - 
+      positions: [0.0, 0.0154, 0.1174, 0.0436, 0.0, 0.9002, 1.3299, 0.0436]
+      velocities: [0.0, -0.1578, -0.086, 0.0, 0.0, -0.1745, -0.7272, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 336500000
+    - 
+      positions: [0.0, 0.0139, 0.1165, 0.0436, 0.0, 0.8986, 1.3224, 0.0436]
+      velocities: [0.0, -0.1565, -0.0872, -0.0, 0.0, -0.1857, -0.7485, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, -0.0649, 0.0407, 0.0436, 0.0, 0.2842, 0.5009, 0.0436]
+      velocities: [0.0, -0.0707, -0.1057, 0.0, 0.0, -1.0447, -1.2621, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  54100000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 700000000
+duration: 
+  secs: 2
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/test_versions-v/rough_terrain_high_step/right_open/MV_RT_highstep_rightopen_v5.subgait
+++ b/march_gait_files/test_versions-v/rough_terrain_high_step/right_open/MV_RT_highstep_rightopen_v5.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "Removed ankle from gait."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 619100000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  12399999
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 176500000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 336500000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 836000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 466200000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.1537, 0.7636, 0.0436, 0.0, -0.1056, 0.0362, 0.0436]
+      velocities: [0.0, 2.0, 1.833, 0.0, 0.0, -0.0541, 0.101, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 619100000
+    - 
+      positions: [0.0, 0.7495, 1.3552, 0.0436, 0.0, -0.1308, 0.0795, 0.0436]
+      velocities: [0.0, 1.0405, 0.9416, -0.0, 0.0, -0.0723, 0.1132, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  12399999
+    - 
+      positions: [0.0, 0.8767, 1.4392, 0.0436, 0.0, -0.1436, 0.0983, 0.0436]
+      velocities: [0.0, 0.4692, 0.0, 0.0, 0.0, -0.0762, 0.1055, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 176500000
+    - 
+      positions: [0.0, 0.9002, 1.3852, 0.0436, 0.0, -0.1559, 0.1141, 0.0436]
+      velocities: [0.0, -0.1745, -0.6337, 0.0, 0.0, -0.0775, 0.0911, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 336500000
+    - 
+      positions: [0.0, 0.8987, 1.3785, 0.0436, 0.0, -0.1567, 0.115, 0.0436]
+      velocities: [0.0, -0.1767, -0.6692, -0.0, 0.0, -0.0776, 0.09, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, 0.742, 0.7812, 0.0436, 0.0, -0.1925, 0.1396, 0.0436]
+      velocities: [0.0, -0.4325, -1.5115, 0.0, 0.0, -0.0681, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 836000000
+    - 
+      positions: [0.0, 0.4455, 0.1396, 0.0436, 0.0, -0.2238, 0.1396, 0.0436]
+      velocities: [0.0, -0.4439, 0.0, 0.0, 0.0, -0.0257, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 466200000
+    - 
+      positions: [0.0, 0.3491, 0.1396, 0.0436, 0.0, -0.2269, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 700000000
+duration: 
+  secs: 2
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/test_versions-v/rough_terrain_high_step/right_open/MV_RT_highstep_rightopen_v6.subgait
+++ b/march_gait_files/test_versions-v/rough_terrain_high_step/right_open/MV_RT_highstep_rightopen_v6.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "Added a little more knee flexion in the left knee."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 619100000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  12399999
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 176500000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 336500000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 836000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 466200000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.1537, 0.7636, 0.0436, 0.0, -0.1056, 0.0362, 0.0436]
+      velocities: [0.0, 2.0, 1.833, 0.0, 0.0, -0.0541, 0.101, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 619100000
+    - 
+      positions: [0.0, 0.7495, 1.3552, 0.0436, 0.0, -0.1308, 0.0795, 0.0436]
+      velocities: [0.0, 1.0405, 0.9416, -0.0, 0.0, -0.0723, 0.1132, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  12399999
+    - 
+      positions: [0.0, 0.8767, 1.4392, 0.0436, 0.0, -0.1436, 0.0983, 0.0436]
+      velocities: [0.0, 0.4692, 0.0, 0.0, 0.0, -0.0762, 0.1055, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 176500000
+    - 
+      positions: [0.0, 0.9002, 1.3852, 0.0436, 0.0, -0.1559, 0.1141, 0.0436]
+      velocities: [0.0, -0.1745, -0.6337, 0.0, 0.0, -0.0775, 0.0911, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 336500000
+    - 
+      positions: [0.0, 0.8987, 1.3785, 0.0436, 0.0, -0.1567, 0.115, 0.0436]
+      velocities: [0.0, -0.1767, -0.6692, -0.0, 0.0, -0.0776, 0.09, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, 0.742, 0.7812, 0.0436, 0.0, -0.1925, 0.1396, 0.0436]
+      velocities: [0.0, -0.4325, -1.5115, 0.0, 0.0, -0.0681, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 836000000
+    - 
+      positions: [0.0, 0.4455, 0.1396, 0.0436, 0.0, -0.2238, 0.3093, 0.0436]
+      velocities: [0.0, -0.4439, 0.0, 0.0, 0.0, -0.0257, 0.2962, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 466200000
+    - 
+      positions: [0.0, 0.3491, 0.1396, 0.0436, 0.0, -0.2269, 0.3491, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 700000000
+duration: 
+  secs: 2
+  nsecs: 700000000
+sounds: []


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
--> Following the last training, when the left toe often touched the beam on the Rough Terrain, I adjusted the high step so that this should happen less often. I have added a little knee flexion at the transition between right_open and left_close (more hip extension was not possible). It looked fine in the simulation so I already moved it to the airgait-v directory and set it as default there.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
--> New default version of the Rough Terrain high step in test_versions-v and airgait-v.

<!-- Please don't forget to request for reviews -->
