### PR TITLE
Feature/slope down smaller ankle angles

### DIFF
--- a/march_gait_files/airgait-v/ramp_door_last_step/left_close/MV_RD_laststep_leftclose_v3.subgait
+++ b/march_gait_files/airgait-v/ramp_door_last_step/left_close/MV_RD_laststep_leftclose_v3.subgait
@@ -1,0 +1,125 @@
+name: ''
+version: ''
+description: "The left close for the single step off the ramp, with ankle -5."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 800000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 937400000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 250000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  83299999
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, -0.0873, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4601, 0.8727, -0.0448, 0.0, 0.1105, 0.1064, 0.0436]
+      velocities: [0.0, 0.7666, 0.0, 0.0887, 0.0, -0.1656, -0.0723, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 800000000
+    - 
+      positions: [0.0, 0.5413, 0.8573, -0.032, 0.0, 0.0897, 0.0957, 0.0436]
+      velocities: [0.0, 0.39, -0.2155, 0.0931, 0.0, -0.1329, -0.0782, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 937400000
+    - 
+      positions: [0.0, 0.5585, 0.8412, -0.0263, 0.0, 0.0822, 0.0909, 0.0436]
+      velocities: [0.0, 0.1396, -0.3043, 0.094, 0.0, -0.1189, -0.0801, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, 0.5364, 0.7246, -0.0029, 0.0, 0.06, 0.0702, 0.0436]
+      velocities: [0.0, -0.2861, -0.5908, 0.0908, 0.0, -0.0605, -0.0838, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 250000000
+    - 
+      positions: [0.0, 0.4244, 0.5536, 0.0183, 0.0, 0.0524, 0.0495, 0.0436]
+      velocities: [0.0, -0.5671, -0.7431, 0.0767, 0.0, 0.0, -0.0806, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.049, 0.1345, 0.0436, 0.0, -0.0337, 0.0106, 0.0436]
+      velocities: [0.0, -0.5713, -0.5791, 0.0, 0.0, -0.205, -0.0474, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  83299999
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_last_step/left_close/MV_RD_laststep_leftclose_v4.subgait
+++ b/march_gait_files/airgait-v/ramp_door_last_step/left_close/MV_RD_laststep_leftclose_v4.subgait
@@ -1,0 +1,125 @@
+name: ''
+version: ''
+description: "The left close for the single step off the ramp, with ankle -10."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 800000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 937400000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 250000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  83299999
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, -0.1745, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4601, 0.8727, -0.1037, 0.0, 0.1105, 0.1064, 0.0436]
+      velocities: [0.0, 0.7666, 0.0, 0.1477, 0.0, -0.1656, -0.0723, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 800000000
+    - 
+      positions: [0.0, 0.5413, 0.8573, -0.0823, 0.0, 0.0897, 0.0957, 0.0436]
+      velocities: [0.0, 0.39, -0.2155, 0.1552, 0.0, -0.1329, -0.0782, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 937400000
+    - 
+      positions: [0.0, 0.5585, 0.8412, -0.0729, 0.0, 0.0822, 0.0909, 0.0436]
+      velocities: [0.0, 0.1396, -0.3043, 0.1566, 0.0, -0.1189, -0.0801, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, 0.5364, 0.7246, -0.0339, 0.0, 0.06, 0.0702, 0.0436]
+      velocities: [0.0, -0.2861, -0.5908, 0.1513, 0.0, -0.0605, -0.0838, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 250000000
+    - 
+      positions: [0.0, 0.4244, 0.5536, 0.0014, 0.0, 0.0524, 0.0495, 0.0436]
+      velocities: [0.0, -0.5671, -0.7431, 0.1278, 0.0, 0.0, -0.0806, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.049, 0.1345, 0.0436, 0.0, -0.0337, 0.0106, 0.0436]
+      velocities: [0.0, -0.5713, -0.5791, 0.0, 0.0, -0.205, -0.0474, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  83299999
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_last_step/right_open/MV_RD_laststep_rightopen_v3.subgait
+++ b/march_gait_files/airgait-v/ramp_door_last_step/right_open/MV_RD_laststep_rightopen_v3.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The right open for the single step off the ramp, with ankle -5."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 937400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 250000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 700000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  83299999
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 250000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, -0.0873, 0.0, -0.0873, 0.0, -0.0873]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3213, 0.843, -0.032, 0.0, -0.1123, 0.0801, -0.0873]
+      velocities: [0.0, 0.5968, 0.5095, 0.0931, 0.0, -0.0445, 0.1221, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 937400000
+    - 
+      positions: [0.0, 0.385, 0.8727, -0.0216, 0.0, -0.1173, 0.0933, -0.0873]
+      velocities: [0.0, 0.5574, 0.0, 0.0942, 0.0, -0.0463, 0.1171, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.4843, 0.8179, -0.0029, 0.0, -0.1268, 0.115, -0.0873]
+      velocities: [0.0, 0.4256, -0.5168, 0.0908, 0.0, -0.0476, 0.0972, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 250000000
+    - 
+      positions: [0.0, 0.5585, 0.6309, 0.0183, 0.0, -0.1386, 0.1341, -0.0873]
+      velocities: [0.0, 0.1396, -0.9016, 0.0767, 0.0, -0.0459, 0.0531, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.5624, 0.4395, 0.0318, 0.0, -0.1474, 0.1396, -0.0873]
+      velocities: [0.0, -0.0839, -0.965, 0.0575, 0.0, -0.0417, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 700000000
+    - 
+      positions: [0.0, 0.4715, 0.14, 0.0436, 0.0, -0.1607, 0.1396, -0.0873]
+      velocities: [0.0, -0.3454, -0.4871, 0.0, 0.0, -0.027, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  83299999
+    - 
+      positions: [0.0, 0.4084, 0.0969, 0.0436, 0.0, -0.1645, 0.1396, -0.0873]
+      velocities: [0.0, -0.3835, 0.0, -0.0, 0.0, -0.0175, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 250000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, -0.0873]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_last_step/right_open/MV_RD_laststep_rightopen_v4.subgait
+++ b/march_gait_files/airgait-v/ramp_door_last_step/right_open/MV_RD_laststep_rightopen_v4.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The right open for the single step off the ramp, with ankle -10."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 937400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 250000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 700000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  83299999
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 250000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, -0.1745, 0.0, -0.0873, 0.0, -0.1745]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3213, 0.843, -0.0823, 0.0, -0.1123, 0.0801, -0.1745]
+      velocities: [0.0, 0.5968, 0.5095, 0.1552, 0.0, -0.0445, 0.1221, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 937400000
+    - 
+      positions: [0.0, 0.385, 0.8727, -0.0651, 0.0, -0.1173, 0.0933, -0.1745]
+      velocities: [0.0, 0.5574, 0.0, 0.157, 0.0, -0.0463, 0.1171, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.4843, 0.8179, -0.0339, 0.0, -0.1268, 0.115, -0.1745]
+      velocities: [0.0, 0.4256, -0.5168, 0.1513, 0.0, -0.0476, 0.0972, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 250000000
+    - 
+      positions: [0.0, 0.5585, 0.6309, 0.0014, 0.0, -0.1386, 0.1341, -0.1745]
+      velocities: [0.0, 0.1396, -0.9016, 0.1278, 0.0, -0.0459, 0.0531, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.5624, 0.4395, 0.0239, 0.0, -0.1474, 0.1396, -0.1745]
+      velocities: [0.0, -0.0839, -0.965, 0.0959, 0.0, -0.0417, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 700000000
+    - 
+      positions: [0.0, 0.4715, 0.14, 0.0436, 0.0, -0.1607, 0.1396, -0.1745]
+      velocities: [0.0, -0.3454, -0.4871, 0.0, 0.0, -0.027, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  83299999
+    - 
+      positions: [0.0, 0.4084, 0.0969, 0.0436, 0.0, -0.1645, 0.1396, -0.1745]
+      velocities: [0.0, -0.3835, 0.0, -0.0, 0.0, -0.0175, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 250000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, -0.1745]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_slope_down/left_close/MV_RD_slopedown_leftclose_v3.subgait
+++ b/march_gait_files/airgait-v/ramp_door_slope_down/left_close/MV_RD_slopedown_leftclose_v3.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "One of the two options for the closing step on the ramp, with ankle -5."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 750000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_ankle, left_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 950000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 464900000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 627500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.0873, 0.0, 0.1745, 0.6981, -0.0873]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3746, 0.5251, -0.0873, 0.0, 0.4768, 0.8731, -0.0873]
+      velocities: [0.0, -0.2023, -0.0, 0.0, 0.0, 0.4555, 0.2333, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 750000000
+    - 
+      positions: [0.0, 0.3062, 0.4462, -0.0873, 0.0, 0.5558, 0.9003, -0.0873]
+      velocities: [0.0, -0.247, -0.4794, 0.0, 0.0, 0.0, -0.0818, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.2678, 0.3626, -0.0873, 0.0, 0.5458, 0.8668, -0.0873]
+      velocities: [0.0, -0.2611, -0.6091, -0.0, 0.0, -0.131, -0.3491, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+    - 
+      positions: [0.0, 0.1869, 0.1692, -0.0873, 0.0, 0.4706, 0.7326, -0.0873]
+      velocities: [0.0, -0.2728, -0.6206, 0.0, 0.0, -0.3457, -0.5418, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.0673, 0.0, -0.0873, 0.0, 0.273, 0.4539, -0.0873]
+      velocities: [0.0, -0.2492, 0.0, 0.0, 0.0, -0.4911, -0.6515, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 950000000
+    - 
+      positions: [0.0, -0.0403, 0.0, -0.0873, 0.0, 0.0341, 0.1485, -0.0873]
+      velocities: [0.0, -0.1626, 0.0, 0.0, -0.0, -0.3993, -0.4956, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 464900000
+    - 
+      positions: [0.0, -0.0631, 0.0, -0.0873, 0.0, -0.0232, 0.078, -0.0873]
+      velocities: [-0.0, -0.1224, 0.0, 0.0, 0.0, -0.3143, -0.3854, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 627500000
+    - 
+      positions: [0.0, -0.0873, 0.0, -0.0873, 0.0, -0.0873, 0.0, -0.0873]
+      velocities: [-0.0, -0.0, 0.0, 0.0, -0.0, -0.0, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_slope_down/left_close/MV_RD_slopedown_leftclose_v4.subgait
+++ b/march_gait_files/airgait-v/ramp_door_slope_down/left_close/MV_RD_slopedown_leftclose_v4.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "One of the two options for the closing step on the ramp, with ankle -10."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 750000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_ankle, left_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 950000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 464900000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 627500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.1745, 0.0, 0.1745, 0.6981, -0.1745]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3746, 0.5251, -0.1745, 0.0, 0.4768, 0.8731, -0.1745]
+      velocities: [0.0, -0.2023, -0.0, -0.0, 0.0, 0.4555, 0.2333, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 750000000
+    - 
+      positions: [0.0, 0.3062, 0.4462, -0.1745, 0.0, 0.5558, 0.9003, -0.1745]
+      velocities: [0.0, -0.247, -0.4794, 0.0, 0.0, 0.0, -0.0818, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.2678, 0.3626, -0.1745, 0.0, 0.5458, 0.8668, -0.1745]
+      velocities: [0.0, -0.2611, -0.6091, 0.0, 0.0, -0.131, -0.3491, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+    - 
+      positions: [0.0, 0.1869, 0.1692, -0.1745, 0.0, 0.4706, 0.7326, -0.1745]
+      velocities: [0.0, -0.2728, -0.6206, -0.0, 0.0, -0.3457, -0.5418, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.0673, 0.0, -0.1745, 0.0, 0.273, 0.4539, -0.1745]
+      velocities: [0.0, -0.2492, 0.0, 0.0, 0.0, -0.4911, -0.6515, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 950000000
+    - 
+      positions: [0.0, -0.0403, 0.0, -0.1745, 0.0, 0.0341, 0.1485, -0.1745]
+      velocities: [0.0, -0.1626, 0.0, 0.0, -0.0, -0.3993, -0.4956, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 464900000
+    - 
+      positions: [0.0, -0.0631, 0.0, -0.1745, 0.0, -0.0232, 0.078, -0.1745]
+      velocities: [-0.0, -0.1224, 0.0, 0.0, 0.0, -0.3143, -0.3854, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 627500000
+    - 
+      positions: [0.0, -0.0873, 0.0, -0.1745, 0.0, -0.0873, 0.0, -0.1745]
+      velocities: [-0.0, -0.0, 0.0, -0.0, -0.0, -0.0, -0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_slope_down/left_open/MV_RD_slopedown_leftopen_v3.subgait
+++ b/march_gait_files/airgait-v/ramp_door_slope_down/left_open/MV_RD_slopedown_leftopen_v3.subgait
@@ -1,0 +1,177 @@
+name: ''
+version: ''
+description: "The left open step for the ramp down, so the second step, with ankle -5."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 500000000
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 999900000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 242299999
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 793500000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 464900000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 627500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.0873, 0.0, 0.1745, 0.6981, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3377, 0.2065, -0.0873, 0.0, 0.2349, 0.6981, 0.0436]
+      velocities: [0.0, -0.3874, 0.0, 0.0, 0.0, 0.2009, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.2984, 0.2065, -0.0873, 0.0, 0.2557, 0.6981, 0.0428]
+      velocities: [0.0, -0.3925, 0.0, 0.0, 0.0, 0.2102, 0.0, -0.0163]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.1745, 0.2065, -0.0873, 0.0, 0.3309, 0.6183, 0.0236]
+      velocities: [0.0, -0.1449, 0.0, -0.0, 0.0, 0.1372, -0.3617, -0.0725]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 999900000
+    - 
+      positions: [0.0, 0.1685, 0.2065, -0.0873, 0.0, 0.3371, 0.5993, 0.0199]
+      velocities: [0.0, -0.1339, 0.0, 0.0, 0.0, 0.1157, -0.391, -0.0773]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.148, 0.2188, -0.0873, 0.0, 0.3491, 0.5163, 0.0036]
+      velocities: [0.0, -0.0842, 0.1262, 0.0, 0.0, -0.0, -0.4658, -0.091]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 242299999
+    - 
+      positions: [0.0, 0.1339, 0.2716, -0.0873, 0.0, 0.3552, 0.3912, -0.0214]
+      velocities: [0.0, -0.029, 0.2643, 0.0, 0.0, 0.0451, -0.4747, -0.0982]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.1325, 0.3637, -0.0873, 0.0, 0.374, 0.2649, -0.0492]
+      velocities: [0.0, 0.0151, 0.3545, -0.0, 0.0, 0.0792, -0.3491, -0.0904]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 793500000
+    - 
+      positions: [0.0, 0.159, 0.6053, -0.0873, 0.0, 0.4336, 0.1845, -0.0871]
+      velocities: [0.0, 0.0467, 0.3052, 0.0, -0.0, 0.0799, 0.0293, -0.009]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 464900000
+    - 
+      positions: [0.0, 0.1608, 0.6172, -0.0873, 0.0, 0.4367, 0.1859, -0.0873]
+      velocities: [0.0, 0.0455, 0.2909, 0.0, 0.0, 0.0765, 0.0378, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.166, 0.6491, -0.0873, 0.0, 0.4451, 0.1915, -0.0873]
+      velocities: [-0.0, 0.0398, 0.2403, 0.0, 0.0, 0.0639, 0.053, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 627500000
+    - 
+      positions: [0.0, 0.1745, 0.6981, -0.0873, 0.0, 0.4583, 0.2065, -0.0873]
+      velocities: [-0.0, -0.0, 0.0, 0.0, -0.0, -0.0, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_slope_down/left_open/MV_RD_slopedown_leftopen_v4.subgait
+++ b/march_gait_files/airgait-v/ramp_door_slope_down/left_open/MV_RD_slopedown_leftopen_v4.subgait
@@ -1,0 +1,177 @@
+name: ''
+version: ''
+description: "The left open step for the ramp down, so the second step, with ankle -10."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 500000000
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 999900000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 242299999
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 793500000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 464900000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 627500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.1745, 0.0, 0.1745, 0.6981, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3377, 0.2065, -0.1745, 0.0, 0.2349, 0.6981, 0.0436]
+      velocities: [0.0, -0.3874, 0.0, 0.0, 0.0, 0.2009, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.2984, 0.2065, -0.1745, 0.0, 0.2557, 0.6981, 0.0423]
+      velocities: [0.0, -0.3925, 0.0, -0.0, 0.0, 0.2102, 0.0, -0.0272]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.1745, 0.2065, -0.1745, 0.0, 0.3309, 0.6183, 0.0103]
+      velocities: [0.0, -0.1449, 0.0, 0.0, 0.0, 0.1372, -0.3617, -0.1207]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 999900000
+    - 
+      positions: [0.0, 0.1685, 0.2065, -0.1745, 0.0, 0.3371, 0.5993, 0.004]
+      velocities: [0.0, -0.1339, 0.0, 0.0, 0.0, 0.1157, -0.391, -0.1287]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.148, 0.2188, -0.1745, 0.0, 0.3491, 0.5163, -0.023]
+      velocities: [0.0, -0.0842, 0.1262, 0.0, 0.0, -0.0, -0.4658, -0.1516]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 242299999
+    - 
+      positions: [0.0, 0.1339, 0.2716, -0.1745, 0.0, 0.3552, 0.3912, -0.0646]
+      velocities: [0.0, -0.029, 0.2643, -0.0, 0.0, 0.0451, -0.4747, -0.1636]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.1325, 0.3637, -0.1745, 0.0, 0.374, 0.2649, -0.1109]
+      velocities: [0.0, 0.0151, 0.3545, 0.0, 0.0, 0.0792, -0.3491, -0.1507]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 793500000
+    - 
+      positions: [0.0, 0.159, 0.6053, -0.1745, 0.0, 0.4336, 0.1845, -0.1742]
+      velocities: [0.0, 0.0467, 0.3052, 0.0, -0.0, 0.0799, 0.0293, -0.015]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 464900000
+    - 
+      positions: [0.0, 0.1608, 0.6172, -0.1745, 0.0, 0.4367, 0.1859, -0.1745]
+      velocities: [0.0, 0.0455, 0.2909, 0.0, 0.0, 0.0765, 0.0378, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.166, 0.6491, -0.1745, 0.0, 0.4451, 0.1915, -0.1745]
+      velocities: [-0.0, 0.0398, 0.2403, 0.0, 0.0, 0.0639, 0.053, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 627500000
+    - 
+      positions: [0.0, 0.1745, 0.6981, -0.1745, 0.0, 0.4583, 0.2065, -0.1745]
+      velocities: [-0.0, -0.0, 0.0, -0.0, -0.0, -0.0, -0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_slope_down/left_swing/MV_RD_slopedown_leftswing_v3.subgait
+++ b/march_gait_files/airgait-v/ramp_door_slope_down/left_swing/MV_RD_slopedown_leftswing_v3.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The right swing step for the ramp down, with ankle -5."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 372500000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 535100000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 742900000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 907600000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 498799999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_ankle, right_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  59099999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.1745, 0.6981, -0.0873, 0.0, 0.4583, 0.2065, -0.0873]
+      velocities: [0.0, 0.0, -0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.2404, 0.8019, -0.0873, 0.0, 0.4463, 0.2288, -0.0873]
+      velocities: [0.0, 0.2872, 0.4195, 0.0, 0.0, -0.0608, 0.1154, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 372500000
+    - 
+      positions: [0.0, 0.2878, 0.8651, -0.0873, 0.0, 0.4347, 0.2512, -0.0873]
+      velocities: [0.0, 0.2906, 0.3462, 0.0, 0.0, -0.0822, 0.1599, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 535100000
+    - 
+      positions: [0.0, 0.3392, 0.9059, -0.0873, 0.0, 0.4148, 0.2908, -0.0873]
+      velocities: [0.0, 0.1817, -0.0, 0.0, 0.0, -0.1052, 0.2126, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 742900000
+    - 
+      positions: [0.0, 0.355, 0.8771, -0.0873, 0.0, 0.3966, 0.328, -0.0873]
+      velocities: [0.0, 0.0, -0.3346, -0.0, 0.0, -0.119, 0.2484, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 907600000
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.0873, 0.0, 0.3171, 0.5089, -0.0873]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.3491, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 498799999
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.0873, 0.0, 0.3171, 0.5076, -0.0873]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.348, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4143, 0.1998, -0.0873, 0.0, 0.241, 0.6448, -0.0873]
+      velocities: [0.0, 0.0734, 0.0, 0.0, 0.0, -0.1227, 0.1528, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  59099999
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.0873, 0.0, 0.1745, 0.6981, -0.0873]
+      velocities: [0.0, -0.0, -0.0, 0.0, 0.0, 0.0, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_slope_down/left_swing/MV_RD_slopedown_leftswing_v4.subgait
+++ b/march_gait_files/airgait-v/ramp_door_slope_down/left_swing/MV_RD_slopedown_leftswing_v4.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The right swing step for the ramp down, with ankle -10."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 372500000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 535100000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 742900000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 907600000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 498799999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_ankle, right_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  59099999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.1745, 0.6981, -0.1745, 0.0, 0.4583, 0.2065, -0.1745]
+      velocities: [0.0, 0.0, -0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.2404, 0.8019, -0.1745, 0.0, 0.4463, 0.2288, -0.1745]
+      velocities: [0.0, 0.2872, 0.4195, 0.0, 0.0, -0.0608, 0.1154, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 372500000
+    - 
+      positions: [0.0, 0.2878, 0.8651, -0.1745, 0.0, 0.4347, 0.2512, -0.1745]
+      velocities: [0.0, 0.2906, 0.3462, 0.0, 0.0, -0.0822, 0.1599, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 535100000
+    - 
+      positions: [0.0, 0.3392, 0.9059, -0.1745, 0.0, 0.4148, 0.2908, -0.1745]
+      velocities: [0.0, 0.1817, -0.0, -0.0, 0.0, -0.1052, 0.2126, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 742900000
+    - 
+      positions: [0.0, 0.355, 0.8771, -0.1745, 0.0, 0.3966, 0.328, -0.1745]
+      velocities: [0.0, 0.0, -0.3346, 0.0, 0.0, -0.119, 0.2484, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 907600000
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.1745, 0.0, 0.3171, 0.5089, -0.1745]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.3491, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 498799999
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.1745, 0.0, 0.3171, 0.5076, -0.1745]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.348, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4143, 0.1998, -0.1745, 0.0, 0.241, 0.6448, -0.1745]
+      velocities: [0.0, 0.0734, 0.0, 0.0, 0.0, -0.1227, 0.1528, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  59099999
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.1745, 0.0, 0.1745, 0.6981, -0.1745]
+      velocities: [0.0, -0.0, -0.0, 0.0, 0.0, 0.0, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_slope_down/right_close/MV_RD_slopedown_rightclose_v3.subgait
+++ b/march_gait_files/airgait-v/ramp_door_slope_down/right_close/MV_RD_slopedown_rightclose_v3.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "One of the two options for the closing step on the ramp, with ankle -5."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 750000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_ankle, right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 950000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 464900000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 627500000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.0873, 0.0, 0.1745, 0.6981, -0.0873]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3746, 0.5251, -0.0873, 0.0, 0.4768, 0.8731, -0.0873]
+      velocities: [0.0, -0.2023, -0.0, 0.0, 0.0, 0.4555, 0.2333, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 750000000
+    - 
+      positions: [0.0, 0.3062, 0.4462, -0.0873, 0.0, 0.5558, 0.9003, -0.0873]
+      velocities: [0.0, -0.247, -0.4794, 0.0, 0.0, 0.0, -0.0818, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.2678, 0.3626, -0.0873, 0.0, 0.5458, 0.8668, -0.0873]
+      velocities: [0.0, -0.2611, -0.6091, -0.0, 0.0, -0.131, -0.3491, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+    - 
+      positions: [0.0, 0.1869, 0.1692, -0.0873, 0.0, 0.4706, 0.7326, -0.0873]
+      velocities: [0.0, -0.2728, -0.6206, 0.0, 0.0, -0.3457, -0.5418, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.0673, 0.0, -0.0873, 0.0, 0.273, 0.4539, -0.0873]
+      velocities: [0.0, -0.2492, 0.0, 0.0, 0.0, -0.4911, -0.6515, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 950000000
+    - 
+      positions: [0.0, -0.0403, 0.0, -0.0873, 0.0, 0.0341, 0.1485, -0.0873]
+      velocities: [0.0, -0.1626, 0.0, 0.0, -0.0, -0.3993, -0.4956, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 464900000
+    - 
+      positions: [0.0, -0.0631, 0.0, -0.0873, 0.0, -0.0232, 0.078, -0.0873]
+      velocities: [-0.0, -0.1224, 0.0, 0.0, 0.0, -0.3143, -0.3854, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 627500000
+    - 
+      positions: [0.0, -0.0873, 0.0, -0.0873, 0.0, -0.0873, 0.0, -0.0873]
+      velocities: [-0.0, -0.0, 0.0, 0.0, -0.0, -0.0, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_slope_down/right_close/MV_RD_slopedown_rightclose_v4.subgait
+++ b/march_gait_files/airgait-v/ramp_door_slope_down/right_close/MV_RD_slopedown_rightclose_v4.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "One of the two options for the closing step on the ramp, with ankle -10."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 750000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_ankle, right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 950000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 464900000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 627500000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.1745, 0.0, 0.1745, 0.6981, -0.1745]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3746, 0.5251, -0.1745, 0.0, 0.4768, 0.8731, -0.1745]
+      velocities: [0.0, -0.2023, -0.0, -0.0, 0.0, 0.4555, 0.2333, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 750000000
+    - 
+      positions: [0.0, 0.3062, 0.4462, -0.1745, 0.0, 0.5558, 0.9003, -0.1745]
+      velocities: [0.0, -0.247, -0.4794, 0.0, 0.0, 0.0, -0.0818, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.2678, 0.3626, -0.1745, 0.0, 0.5458, 0.8668, -0.1745]
+      velocities: [0.0, -0.2611, -0.6091, 0.0, 0.0, -0.131, -0.3491, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+    - 
+      positions: [0.0, 0.1869, 0.1692, -0.1745, 0.0, 0.4706, 0.7326, -0.1745]
+      velocities: [0.0, -0.2728, -0.6206, -0.0, 0.0, -0.3457, -0.5418, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.0673, 0.0, -0.1745, 0.0, 0.273, 0.4539, -0.1745]
+      velocities: [0.0, -0.2492, 0.0, 0.0, 0.0, -0.4911, -0.6515, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 950000000
+    - 
+      positions: [0.0, -0.0403, 0.0, -0.1745, 0.0, 0.0341, 0.1485, -0.1745]
+      velocities: [0.0, -0.1626, 0.0, 0.0, -0.0, -0.3993, -0.4956, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 464900000
+    - 
+      positions: [0.0, -0.0631, 0.0, -0.1745, 0.0, -0.0232, 0.078, -0.1745]
+      velocities: [-0.0, -0.1224, 0.0, 0.0, 0.0, -0.3143, -0.3854, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 627500000
+    - 
+      positions: [0.0, -0.0873, 0.0, -0.1745, 0.0, -0.0873, 0.0, -0.1745]
+      velocities: [-0.0, -0.0, 0.0, -0.0, -0.0, -0.0, -0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_slope_down/right_open/MV_RD_slopedown_rightopen_v3.subgait
+++ b/march_gait_files/airgait-v/ramp_door_slope_down/right_open/MV_RD_slopedown_rightopen_v3.subgait
@@ -1,0 +1,151 @@
+name: ''
+version: ''
+description: "The right open step for the ramp down with ankle -5."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 372500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 500000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 535100000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 900000000
+    joint_names: [right_knee, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 900300000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 100000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.0611, 0.2583, 0.0436, 0.0, -0.0933, 0.0, 0.0436]
+      velocities: [0.0, 0.6558, 1.1231, 0.0, 0.0, -0.027, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 372500000
+    - 
+      positions: [0.0, 0.1433, 0.3974, 0.0436, 0.0, -0.0968, 0.0, 0.0436]
+      velocities: [0.0, 0.6927, 1.1557, 0.0, 0.0, -0.0291, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.171, 0.4431, 0.0435, 0.0, -0.0979, 0.0, 0.0436]
+      velocities: [0.0, 0.6853, 1.1296, -0.0052, 0.0, -0.029, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 535100000
+    - 
+      positions: [0.0, 0.348, 0.6981, 0.0304, 0.0, -0.1061, 0.0, 0.0436]
+      velocities: [0.0, 0.1763, 0.0, -0.0614, 0.0, -0.0116, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 900000000
+    - 
+      positions: [0.0, 0.3491, 0.698, 0.0304, 0.0, -0.1061, 0.0, 0.0436]
+      velocities: [0.0, 0.1449, 0.0614, -0.0614, 0.0, -0.0116, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 900300000
+    - 
+      positions: [0.0, 0.4147, 0.4521, -0.0214, 0.0, -0.0873, 0.1364, 0.0436]
+      velocities: [0.0, 0.0794, -0.6227, -0.0982, 0.0, 0.0873, 0.4029, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4472, 0.1998, -0.0735, 0.0, 0.023, 0.4219, 0.0436]
+      velocities: [0.0, 0.0326, 0.0, -0.0638, 0.0, 0.2405, 0.4895, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 100000000
+    - 
+      positions: [0.0, 0.4558, 0.2026, -0.0873, 0.0, 0.116, 0.5976, 0.0436]
+      velocities: [0.0, 0.0125, 0.011, 0.0, 0.0, 0.2051, 0.3651, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.0873, 0.0, 0.1745, 0.6981, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_slope_down/right_open/MV_RD_slopedown_rightopen_v4.subgait
+++ b/march_gait_files/airgait-v/ramp_door_slope_down/right_open/MV_RD_slopedown_rightopen_v4.subgait
@@ -1,0 +1,151 @@
+name: ''
+version: ''
+description: "The right open step for the ramp down, with ankle -10."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 372500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 500000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 535100000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 900000000
+    joint_names: [right_knee, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 900300000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 100000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.0611, 0.2583, 0.0436, 0.0, -0.0933, 0.0, 0.0436]
+      velocities: [0.0, 0.6558, 1.1231, 0.0, 0.0, -0.027, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 372500000
+    - 
+      positions: [0.0, 0.1433, 0.3974, 0.0436, 0.0, -0.0968, 0.0, 0.0436]
+      velocities: [0.0, 0.6927, 1.1557, 0.0, 0.0, -0.0291, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.171, 0.4431, 0.0434, 0.0, -0.0979, 0.0, 0.0436]
+      velocities: [0.0, 0.6853, 1.1296, -0.0086, 0.0, -0.029, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 535100000
+    - 
+      positions: [0.0, 0.348, 0.6981, 0.0216, 0.0, -0.1061, 0.0, 0.0436]
+      velocities: [0.0, 0.1763, 0.0, -0.1023, 0.0, -0.0116, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 900000000
+    - 
+      positions: [0.0, 0.3491, 0.698, 0.0216, 0.0, -0.1061, 0.0, 0.0436]
+      velocities: [0.0, 0.1449, 0.0614, -0.1023, 0.0, -0.0116, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 900300000
+    - 
+      positions: [0.0, 0.4147, 0.4521, -0.0646, 0.0, -0.0873, 0.1364, 0.0436]
+      velocities: [0.0, 0.0794, -0.6227, -0.1636, 0.0, 0.0873, 0.4029, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4472, 0.1998, -0.1515, 0.0, 0.023, 0.4219, 0.0436]
+      velocities: [0.0, 0.0326, 0.0, -0.1063, 0.0, 0.2405, 0.4895, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 100000000
+    - 
+      positions: [0.0, 0.4558, 0.2026, -0.1745, 0.0, 0.116, 0.5976, 0.0436]
+      velocities: [0.0, 0.0125, 0.011, 0.0, 0.0, 0.2051, 0.3651, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.1745, 0.0, 0.1745, 0.6981, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_slope_down/right_swing/MV_RD_slopedown_rightswing_v3.subgait
+++ b/march_gait_files/airgait-v/ramp_door_slope_down/right_swing/MV_RD_slopedown_rightswing_v3.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The right swing step for the ramp down, with ankle -5."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 372500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 535100000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 742900000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 907600000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 498799999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_ankle, left_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  59099999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.1745, 0.6981, -0.0873, 0.0, 0.4583, 0.2065, -0.0873]
+      velocities: [0.0, 0.0, -0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.2404, 0.8019, -0.0873, 0.0, 0.4463, 0.2288, -0.0873]
+      velocities: [0.0, 0.2872, 0.4195, 0.0, 0.0, -0.0608, 0.1154, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 372500000
+    - 
+      positions: [0.0, 0.2878, 0.8651, -0.0873, 0.0, 0.4347, 0.2512, -0.0873]
+      velocities: [0.0, 0.2906, 0.3462, 0.0, 0.0, -0.0822, 0.1599, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 535100000
+    - 
+      positions: [0.0, 0.3392, 0.9059, -0.0873, 0.0, 0.4148, 0.2908, -0.0873]
+      velocities: [0.0, 0.1817, -0.0, 0.0, 0.0, -0.1052, 0.2126, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 742900000
+    - 
+      positions: [0.0, 0.355, 0.8771, -0.0873, 0.0, 0.3966, 0.328, -0.0873]
+      velocities: [0.0, 0.0, -0.3346, -0.0, 0.0, -0.119, 0.2484, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 907600000
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.0873, 0.0, 0.3171, 0.5089, -0.0873]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.3491, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 498799999
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.0873, 0.0, 0.3171, 0.5076, -0.0873]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.348, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4143, 0.1998, -0.0873, 0.0, 0.241, 0.6448, -0.0873]
+      velocities: [0.0, 0.0734, 0.0, 0.0, 0.0, -0.1227, 0.1528, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  59099999
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.0873, 0.0, 0.1745, 0.6981, -0.0873]
+      velocities: [0.0, -0.0, -0.0, 0.0, 0.0, 0.0, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/ramp_door_slope_down/right_swing/MV_RD_slopedown_rightswing_v4.subgait
+++ b/march_gait_files/airgait-v/ramp_door_slope_down/right_swing/MV_RD_slopedown_rightswing_v4.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The right swing step for the ramp down, with ankle -10."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 372500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 535100000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 742900000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 907600000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 498799999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_ankle, left_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  59099999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.1745, 0.6981, -0.1745, 0.0, 0.4583, 0.2065, -0.1745]
+      velocities: [0.0, 0.0, -0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.2404, 0.8019, -0.1745, 0.0, 0.4463, 0.2288, -0.1745]
+      velocities: [0.0, 0.2872, 0.4195, 0.0, 0.0, -0.0608, 0.1154, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 372500000
+    - 
+      positions: [0.0, 0.2878, 0.8651, -0.1745, 0.0, 0.4347, 0.2512, -0.1745]
+      velocities: [0.0, 0.2906, 0.3462, 0.0, 0.0, -0.0822, 0.1599, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 535100000
+    - 
+      positions: [0.0, 0.3392, 0.9059, -0.1745, 0.0, 0.4148, 0.2908, -0.1745]
+      velocities: [0.0, 0.1817, -0.0, -0.0, 0.0, -0.1052, 0.2126, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 742900000
+    - 
+      positions: [0.0, 0.355, 0.8771, -0.1745, 0.0, 0.3966, 0.328, -0.1745]
+      velocities: [0.0, 0.0, -0.3346, 0.0, 0.0, -0.119, 0.2484, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 907600000
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.1745, 0.0, 0.3171, 0.5089, -0.1745]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.3491, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 498799999
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.1745, 0.0, 0.3171, 0.5076, -0.1745]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.348, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4143, 0.1998, -0.1745, 0.0, 0.241, 0.6448, -0.1745]
+      velocities: [0.0, 0.0734, 0.0, 0.0, 0.0, -0.1227, 0.1528, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  59099999
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.1745, 0.0, 0.1745, 0.6981, -0.1745]
+      velocities: [0.0, -0.0, -0.0, 0.0, 0.0, 0.0, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_last_step/left_close/MV_RD_laststep_leftclose_v3.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_last_step/left_close/MV_RD_laststep_leftclose_v3.subgait
@@ -1,0 +1,125 @@
+name: ''
+version: ''
+description: "The left close for the single step off the ramp, with ankle -5."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 800000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 937400000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 250000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  83299999
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, -0.0873, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4601, 0.8727, -0.0448, 0.0, 0.1105, 0.1064, 0.0436]
+      velocities: [0.0, 0.7666, 0.0, 0.0887, 0.0, -0.1656, -0.0723, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 800000000
+    - 
+      positions: [0.0, 0.5413, 0.8573, -0.032, 0.0, 0.0897, 0.0957, 0.0436]
+      velocities: [0.0, 0.39, -0.2155, 0.0931, 0.0, -0.1329, -0.0782, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 937400000
+    - 
+      positions: [0.0, 0.5585, 0.8412, -0.0263, 0.0, 0.0822, 0.0909, 0.0436]
+      velocities: [0.0, 0.1396, -0.3043, 0.094, 0.0, -0.1189, -0.0801, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, 0.5364, 0.7246, -0.0029, 0.0, 0.06, 0.0702, 0.0436]
+      velocities: [0.0, -0.2861, -0.5908, 0.0908, 0.0, -0.0605, -0.0838, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 250000000
+    - 
+      positions: [0.0, 0.4244, 0.5536, 0.0183, 0.0, 0.0524, 0.0495, 0.0436]
+      velocities: [0.0, -0.5671, -0.7431, 0.0767, 0.0, 0.0, -0.0806, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.049, 0.1345, 0.0436, 0.0, -0.0337, 0.0106, 0.0436]
+      velocities: [0.0, -0.5713, -0.5791, 0.0, 0.0, -0.205, -0.0474, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  83299999
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_last_step/left_close/MV_RD_laststep_leftclose_v4.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_last_step/left_close/MV_RD_laststep_leftclose_v4.subgait
@@ -1,0 +1,125 @@
+name: ''
+version: ''
+description: "The left close for the single step off the ramp, with ankle -10."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 800000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 937400000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 250000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  83299999
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, -0.1745, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4601, 0.8727, -0.1037, 0.0, 0.1105, 0.1064, 0.0436]
+      velocities: [0.0, 0.7666, 0.0, 0.1477, 0.0, -0.1656, -0.0723, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 800000000
+    - 
+      positions: [0.0, 0.5413, 0.8573, -0.0823, 0.0, 0.0897, 0.0957, 0.0436]
+      velocities: [0.0, 0.39, -0.2155, 0.1552, 0.0, -0.1329, -0.0782, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 937400000
+    - 
+      positions: [0.0, 0.5585, 0.8412, -0.0729, 0.0, 0.0822, 0.0909, 0.0436]
+      velocities: [0.0, 0.1396, -0.3043, 0.1566, 0.0, -0.1189, -0.0801, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, 0.5364, 0.7246, -0.0339, 0.0, 0.06, 0.0702, 0.0436]
+      velocities: [0.0, -0.2861, -0.5908, 0.1513, 0.0, -0.0605, -0.0838, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 250000000
+    - 
+      positions: [0.0, 0.4244, 0.5536, 0.0014, 0.0, 0.0524, 0.0495, 0.0436]
+      velocities: [0.0, -0.5671, -0.7431, 0.1278, 0.0, 0.0, -0.0806, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.049, 0.1345, 0.0436, 0.0, -0.0337, 0.0106, 0.0436]
+      velocities: [0.0, -0.5713, -0.5791, 0.0, 0.0, -0.205, -0.0474, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  83299999
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_last_step/right_open/MV_RD_laststep_rightopen_v3.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_last_step/right_open/MV_RD_laststep_rightopen_v3.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The right open for the single step off the ramp, with ankle -5."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 937400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 250000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 700000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  83299999
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 250000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, -0.0873, 0.0, -0.0873, 0.0, -0.0873]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3213, 0.843, -0.032, 0.0, -0.1123, 0.0801, -0.0873]
+      velocities: [0.0, 0.5968, 0.5095, 0.0931, 0.0, -0.0445, 0.1221, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 937400000
+    - 
+      positions: [0.0, 0.385, 0.8727, -0.0216, 0.0, -0.1173, 0.0933, -0.0873]
+      velocities: [0.0, 0.5574, 0.0, 0.0942, 0.0, -0.0463, 0.1171, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.4843, 0.8179, -0.0029, 0.0, -0.1268, 0.115, -0.0873]
+      velocities: [0.0, 0.4256, -0.5168, 0.0908, 0.0, -0.0476, 0.0972, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 250000000
+    - 
+      positions: [0.0, 0.5585, 0.6309, 0.0183, 0.0, -0.1386, 0.1341, -0.0873]
+      velocities: [0.0, 0.1396, -0.9016, 0.0767, 0.0, -0.0459, 0.0531, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.5624, 0.4395, 0.0318, 0.0, -0.1474, 0.1396, -0.0873]
+      velocities: [0.0, -0.0839, -0.965, 0.0575, 0.0, -0.0417, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 700000000
+    - 
+      positions: [0.0, 0.4715, 0.14, 0.0436, 0.0, -0.1607, 0.1396, -0.0873]
+      velocities: [0.0, -0.3454, -0.4871, 0.0, 0.0, -0.027, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  83299999
+    - 
+      positions: [0.0, 0.4084, 0.0969, 0.0436, 0.0, -0.1645, 0.1396, -0.0873]
+      velocities: [0.0, -0.3835, 0.0, -0.0, 0.0, -0.0175, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 250000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, -0.0873]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_last_step/right_open/MV_RD_laststep_rightopen_v4.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_last_step/right_open/MV_RD_laststep_rightopen_v4.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The right open for the single step off the ramp, with ankle -10."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 937400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 250000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 700000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  83299999
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 250000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, -0.1745, 0.0, -0.0873, 0.0, -0.1745]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3213, 0.843, -0.0823, 0.0, -0.1123, 0.0801, -0.1745]
+      velocities: [0.0, 0.5968, 0.5095, 0.1552, 0.0, -0.0445, 0.1221, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 937400000
+    - 
+      positions: [0.0, 0.385, 0.8727, -0.0651, 0.0, -0.1173, 0.0933, -0.1745]
+      velocities: [0.0, 0.5574, 0.0, 0.157, 0.0, -0.0463, 0.1171, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.4843, 0.8179, -0.0339, 0.0, -0.1268, 0.115, -0.1745]
+      velocities: [0.0, 0.4256, -0.5168, 0.1513, 0.0, -0.0476, 0.0972, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 250000000
+    - 
+      positions: [0.0, 0.5585, 0.6309, 0.0014, 0.0, -0.1386, 0.1341, -0.1745]
+      velocities: [0.0, 0.1396, -0.9016, 0.1278, 0.0, -0.0459, 0.0531, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.5624, 0.4395, 0.0239, 0.0, -0.1474, 0.1396, -0.1745]
+      velocities: [0.0, -0.0839, -0.965, 0.0959, 0.0, -0.0417, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 700000000
+    - 
+      positions: [0.0, 0.4715, 0.14, 0.0436, 0.0, -0.1607, 0.1396, -0.1745]
+      velocities: [0.0, -0.3454, -0.4871, 0.0, 0.0, -0.027, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  83299999
+    - 
+      positions: [0.0, 0.4084, 0.0969, 0.0436, 0.0, -0.1645, 0.1396, -0.1745]
+      velocities: [0.0, -0.3835, 0.0, -0.0, 0.0, -0.0175, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 250000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, -0.1745]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_slope_down/left_close/MV_RD_slopedown_leftclose_v3.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_slope_down/left_close/MV_RD_slopedown_leftclose_v3.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "One of the two options for the closing step on the ramp, with ankle -5."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 750000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_ankle, left_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 950000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 464900000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 627500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.0873, 0.0, 0.1745, 0.6981, -0.0873]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3746, 0.5251, -0.0873, 0.0, 0.4768, 0.8731, -0.0873]
+      velocities: [0.0, -0.2023, -0.0, 0.0, 0.0, 0.4555, 0.2333, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 750000000
+    - 
+      positions: [0.0, 0.3062, 0.4462, -0.0873, 0.0, 0.5558, 0.9003, -0.0873]
+      velocities: [0.0, -0.247, -0.4794, 0.0, 0.0, 0.0, -0.0818, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.2678, 0.3626, -0.0873, 0.0, 0.5458, 0.8668, -0.0873]
+      velocities: [0.0, -0.2611, -0.6091, -0.0, 0.0, -0.131, -0.3491, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+    - 
+      positions: [0.0, 0.1869, 0.1692, -0.0873, 0.0, 0.4706, 0.7326, -0.0873]
+      velocities: [0.0, -0.2728, -0.6206, 0.0, 0.0, -0.3457, -0.5418, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.0673, 0.0, -0.0873, 0.0, 0.273, 0.4539, -0.0873]
+      velocities: [0.0, -0.2492, 0.0, 0.0, 0.0, -0.4911, -0.6515, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 950000000
+    - 
+      positions: [0.0, -0.0403, 0.0, -0.0873, 0.0, 0.0341, 0.1485, -0.0873]
+      velocities: [0.0, -0.1626, 0.0, 0.0, -0.0, -0.3993, -0.4956, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 464900000
+    - 
+      positions: [0.0, -0.0631, 0.0, -0.0873, 0.0, -0.0232, 0.078, -0.0873]
+      velocities: [-0.0, -0.1224, 0.0, 0.0, 0.0, -0.3143, -0.3854, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 627500000
+    - 
+      positions: [0.0, -0.0873, 0.0, -0.0873, 0.0, -0.0873, 0.0, -0.0873]
+      velocities: [-0.0, -0.0, 0.0, 0.0, -0.0, -0.0, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_slope_down/left_close/MV_RD_slopedown_leftclose_v4.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_slope_down/left_close/MV_RD_slopedown_leftclose_v4.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "One of the two options for the closing step on the ramp, with ankle -10."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 750000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_ankle, left_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 950000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 464900000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 627500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.1745, 0.0, 0.1745, 0.6981, -0.1745]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3746, 0.5251, -0.1745, 0.0, 0.4768, 0.8731, -0.1745]
+      velocities: [0.0, -0.2023, -0.0, -0.0, 0.0, 0.4555, 0.2333, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 750000000
+    - 
+      positions: [0.0, 0.3062, 0.4462, -0.1745, 0.0, 0.5558, 0.9003, -0.1745]
+      velocities: [0.0, -0.247, -0.4794, 0.0, 0.0, 0.0, -0.0818, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.2678, 0.3626, -0.1745, 0.0, 0.5458, 0.8668, -0.1745]
+      velocities: [0.0, -0.2611, -0.6091, 0.0, 0.0, -0.131, -0.3491, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+    - 
+      positions: [0.0, 0.1869, 0.1692, -0.1745, 0.0, 0.4706, 0.7326, -0.1745]
+      velocities: [0.0, -0.2728, -0.6206, -0.0, 0.0, -0.3457, -0.5418, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.0673, 0.0, -0.1745, 0.0, 0.273, 0.4539, -0.1745]
+      velocities: [0.0, -0.2492, 0.0, 0.0, 0.0, -0.4911, -0.6515, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 950000000
+    - 
+      positions: [0.0, -0.0403, 0.0, -0.1745, 0.0, 0.0341, 0.1485, -0.1745]
+      velocities: [0.0, -0.1626, 0.0, 0.0, -0.0, -0.3993, -0.4956, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 464900000
+    - 
+      positions: [0.0, -0.0631, 0.0, -0.1745, 0.0, -0.0232, 0.078, -0.1745]
+      velocities: [-0.0, -0.1224, 0.0, 0.0, 0.0, -0.3143, -0.3854, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 627500000
+    - 
+      positions: [0.0, -0.0873, 0.0, -0.1745, 0.0, -0.0873, 0.0, -0.1745]
+      velocities: [-0.0, -0.0, 0.0, -0.0, -0.0, -0.0, -0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_slope_down/left_open/MV_RD_slopedown_leftopen_v3.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_slope_down/left_open/MV_RD_slopedown_leftopen_v3.subgait
@@ -1,0 +1,177 @@
+name: ''
+version: ''
+description: "The left open step for the ramp down, so the second step, with ankle -5."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 500000000
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 999900000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 242299999
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 793500000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 464900000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 627500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.0873, 0.0, 0.1745, 0.6981, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3377, 0.2065, -0.0873, 0.0, 0.2349, 0.6981, 0.0436]
+      velocities: [0.0, -0.3874, 0.0, 0.0, 0.0, 0.2009, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.2984, 0.2065, -0.0873, 0.0, 0.2557, 0.6981, 0.0428]
+      velocities: [0.0, -0.3925, 0.0, 0.0, 0.0, 0.2102, 0.0, -0.0163]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.1745, 0.2065, -0.0873, 0.0, 0.3309, 0.6183, 0.0236]
+      velocities: [0.0, -0.1449, 0.0, -0.0, 0.0, 0.1372, -0.3617, -0.0725]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 999900000
+    - 
+      positions: [0.0, 0.1685, 0.2065, -0.0873, 0.0, 0.3371, 0.5993, 0.0199]
+      velocities: [0.0, -0.1339, 0.0, 0.0, 0.0, 0.1157, -0.391, -0.0773]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.148, 0.2188, -0.0873, 0.0, 0.3491, 0.5163, 0.0036]
+      velocities: [0.0, -0.0842, 0.1262, 0.0, 0.0, -0.0, -0.4658, -0.091]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 242299999
+    - 
+      positions: [0.0, 0.1339, 0.2716, -0.0873, 0.0, 0.3552, 0.3912, -0.0214]
+      velocities: [0.0, -0.029, 0.2643, 0.0, 0.0, 0.0451, -0.4747, -0.0982]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.1325, 0.3637, -0.0873, 0.0, 0.374, 0.2649, -0.0492]
+      velocities: [0.0, 0.0151, 0.3545, -0.0, 0.0, 0.0792, -0.3491, -0.0904]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 793500000
+    - 
+      positions: [0.0, 0.159, 0.6053, -0.0873, 0.0, 0.4336, 0.1845, -0.0871]
+      velocities: [0.0, 0.0467, 0.3052, 0.0, -0.0, 0.0799, 0.0293, -0.009]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 464900000
+    - 
+      positions: [0.0, 0.1608, 0.6172, -0.0873, 0.0, 0.4367, 0.1859, -0.0873]
+      velocities: [0.0, 0.0455, 0.2909, 0.0, 0.0, 0.0765, 0.0378, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.166, 0.6491, -0.0873, 0.0, 0.4451, 0.1915, -0.0873]
+      velocities: [-0.0, 0.0398, 0.2403, 0.0, 0.0, 0.0639, 0.053, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 627500000
+    - 
+      positions: [0.0, 0.1745, 0.6981, -0.0873, 0.0, 0.4583, 0.2065, -0.0873]
+      velocities: [-0.0, -0.0, 0.0, 0.0, -0.0, -0.0, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_slope_down/left_open/MV_RD_slopedown_leftopen_v4.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_slope_down/left_open/MV_RD_slopedown_leftopen_v4.subgait
@@ -1,0 +1,177 @@
+name: ''
+version: ''
+description: "The left open step for the ramp down, so the second step, with ankle -10."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 500000000
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 999900000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 242299999
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 793500000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 464900000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 627500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.1745, 0.0, 0.1745, 0.6981, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3377, 0.2065, -0.1745, 0.0, 0.2349, 0.6981, 0.0436]
+      velocities: [0.0, -0.3874, 0.0, 0.0, 0.0, 0.2009, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.2984, 0.2065, -0.1745, 0.0, 0.2557, 0.6981, 0.0423]
+      velocities: [0.0, -0.3925, 0.0, -0.0, 0.0, 0.2102, 0.0, -0.0272]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.1745, 0.2065, -0.1745, 0.0, 0.3309, 0.6183, 0.0103]
+      velocities: [0.0, -0.1449, 0.0, 0.0, 0.0, 0.1372, -0.3617, -0.1207]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 999900000
+    - 
+      positions: [0.0, 0.1685, 0.2065, -0.1745, 0.0, 0.3371, 0.5993, 0.004]
+      velocities: [0.0, -0.1339, 0.0, 0.0, 0.0, 0.1157, -0.391, -0.1287]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.148, 0.2188, -0.1745, 0.0, 0.3491, 0.5163, -0.023]
+      velocities: [0.0, -0.0842, 0.1262, 0.0, 0.0, -0.0, -0.4658, -0.1516]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 242299999
+    - 
+      positions: [0.0, 0.1339, 0.2716, -0.1745, 0.0, 0.3552, 0.3912, -0.0646]
+      velocities: [0.0, -0.029, 0.2643, -0.0, 0.0, 0.0451, -0.4747, -0.1636]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.1325, 0.3637, -0.1745, 0.0, 0.374, 0.2649, -0.1109]
+      velocities: [0.0, 0.0151, 0.3545, 0.0, 0.0, 0.0792, -0.3491, -0.1507]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 793500000
+    - 
+      positions: [0.0, 0.159, 0.6053, -0.1745, 0.0, 0.4336, 0.1845, -0.1742]
+      velocities: [0.0, 0.0467, 0.3052, 0.0, -0.0, 0.0799, 0.0293, -0.015]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 464900000
+    - 
+      positions: [0.0, 0.1608, 0.6172, -0.1745, 0.0, 0.4367, 0.1859, -0.1745]
+      velocities: [0.0, 0.0455, 0.2909, 0.0, 0.0, 0.0765, 0.0378, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.166, 0.6491, -0.1745, 0.0, 0.4451, 0.1915, -0.1745]
+      velocities: [-0.0, 0.0398, 0.2403, 0.0, 0.0, 0.0639, 0.053, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 627500000
+    - 
+      positions: [0.0, 0.1745, 0.6981, -0.1745, 0.0, 0.4583, 0.2065, -0.1745]
+      velocities: [-0.0, -0.0, 0.0, -0.0, -0.0, -0.0, -0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_slope_down/left_swing/MV_RD_slopedown_leftswing_v3.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_slope_down/left_swing/MV_RD_slopedown_leftswing_v3.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The right swing step for the ramp down, with ankle -5."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 372500000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 535100000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 742900000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 907600000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 498799999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_ankle, right_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  59099999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.1745, 0.6981, -0.0873, 0.0, 0.4583, 0.2065, -0.0873]
+      velocities: [0.0, 0.0, -0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.2404, 0.8019, -0.0873, 0.0, 0.4463, 0.2288, -0.0873]
+      velocities: [0.0, 0.2872, 0.4195, 0.0, 0.0, -0.0608, 0.1154, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 372500000
+    - 
+      positions: [0.0, 0.2878, 0.8651, -0.0873, 0.0, 0.4347, 0.2512, -0.0873]
+      velocities: [0.0, 0.2906, 0.3462, 0.0, 0.0, -0.0822, 0.1599, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 535100000
+    - 
+      positions: [0.0, 0.3392, 0.9059, -0.0873, 0.0, 0.4148, 0.2908, -0.0873]
+      velocities: [0.0, 0.1817, -0.0, 0.0, 0.0, -0.1052, 0.2126, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 742900000
+    - 
+      positions: [0.0, 0.355, 0.8771, -0.0873, 0.0, 0.3966, 0.328, -0.0873]
+      velocities: [0.0, 0.0, -0.3346, -0.0, 0.0, -0.119, 0.2484, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 907600000
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.0873, 0.0, 0.3171, 0.5089, -0.0873]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.3491, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 498799999
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.0873, 0.0, 0.3171, 0.5076, -0.0873]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.348, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4143, 0.1998, -0.0873, 0.0, 0.241, 0.6448, -0.0873]
+      velocities: [0.0, 0.0734, 0.0, 0.0, 0.0, -0.1227, 0.1528, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  59099999
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.0873, 0.0, 0.1745, 0.6981, -0.0873]
+      velocities: [0.0, -0.0, -0.0, 0.0, 0.0, 0.0, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_slope_down/left_swing/MV_RD_slopedown_leftswing_v4.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_slope_down/left_swing/MV_RD_slopedown_leftswing_v4.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The right swing step for the ramp down, with ankle -10."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 372500000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 535100000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 742900000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 907600000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 498799999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_ankle, right_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  59099999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.1745, 0.6981, -0.1745, 0.0, 0.4583, 0.2065, -0.1745]
+      velocities: [0.0, 0.0, -0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.2404, 0.8019, -0.1745, 0.0, 0.4463, 0.2288, -0.1745]
+      velocities: [0.0, 0.2872, 0.4195, 0.0, 0.0, -0.0608, 0.1154, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 372500000
+    - 
+      positions: [0.0, 0.2878, 0.8651, -0.1745, 0.0, 0.4347, 0.2512, -0.1745]
+      velocities: [0.0, 0.2906, 0.3462, 0.0, 0.0, -0.0822, 0.1599, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 535100000
+    - 
+      positions: [0.0, 0.3392, 0.9059, -0.1745, 0.0, 0.4148, 0.2908, -0.1745]
+      velocities: [0.0, 0.1817, -0.0, -0.0, 0.0, -0.1052, 0.2126, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 742900000
+    - 
+      positions: [0.0, 0.355, 0.8771, -0.1745, 0.0, 0.3966, 0.328, -0.1745]
+      velocities: [0.0, 0.0, -0.3346, 0.0, 0.0, -0.119, 0.2484, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 907600000
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.1745, 0.0, 0.3171, 0.5089, -0.1745]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.3491, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 498799999
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.1745, 0.0, 0.3171, 0.5076, -0.1745]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.348, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4143, 0.1998, -0.1745, 0.0, 0.241, 0.6448, -0.1745]
+      velocities: [0.0, 0.0734, 0.0, 0.0, 0.0, -0.1227, 0.1528, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  59099999
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.1745, 0.0, 0.1745, 0.6981, -0.1745]
+      velocities: [0.0, -0.0, -0.0, 0.0, 0.0, 0.0, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_slope_down/right_close/MV_RD_slopedown_rightclose_v3.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_slope_down/right_close/MV_RD_slopedown_rightclose_v3.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "One of the two options for the closing step on the ramp, with ankle -5."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 750000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_ankle, right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 950000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 464900000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 627500000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.0873, 0.0, 0.1745, 0.6981, -0.0873]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3746, 0.5251, -0.0873, 0.0, 0.4768, 0.8731, -0.0873]
+      velocities: [0.0, -0.2023, -0.0, 0.0, 0.0, 0.4555, 0.2333, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 750000000
+    - 
+      positions: [0.0, 0.3062, 0.4462, -0.0873, 0.0, 0.5558, 0.9003, -0.0873]
+      velocities: [0.0, -0.247, -0.4794, 0.0, 0.0, 0.0, -0.0818, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.2678, 0.3626, -0.0873, 0.0, 0.5458, 0.8668, -0.0873]
+      velocities: [0.0, -0.2611, -0.6091, -0.0, 0.0, -0.131, -0.3491, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+    - 
+      positions: [0.0, 0.1869, 0.1692, -0.0873, 0.0, 0.4706, 0.7326, -0.0873]
+      velocities: [0.0, -0.2728, -0.6206, 0.0, 0.0, -0.3457, -0.5418, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.0673, 0.0, -0.0873, 0.0, 0.273, 0.4539, -0.0873]
+      velocities: [0.0, -0.2492, 0.0, 0.0, 0.0, -0.4911, -0.6515, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 950000000
+    - 
+      positions: [0.0, -0.0403, 0.0, -0.0873, 0.0, 0.0341, 0.1485, -0.0873]
+      velocities: [0.0, -0.1626, 0.0, 0.0, -0.0, -0.3993, -0.4956, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 464900000
+    - 
+      positions: [0.0, -0.0631, 0.0, -0.0873, 0.0, -0.0232, 0.078, -0.0873]
+      velocities: [-0.0, -0.1224, 0.0, 0.0, 0.0, -0.3143, -0.3854, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 627500000
+    - 
+      positions: [0.0, -0.0873, 0.0, -0.0873, 0.0, -0.0873, 0.0, -0.0873]
+      velocities: [-0.0, -0.0, 0.0, 0.0, -0.0, -0.0, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_slope_down/right_close/MV_RD_slopedown_rightclose_v4.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_slope_down/right_close/MV_RD_slopedown_rightclose_v4.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "One of the two options for the closing step on the ramp, with ankle -10."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 750000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  50000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_ankle, right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 950000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 464900000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 627500000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.1745, 0.0, 0.1745, 0.6981, -0.1745]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3746, 0.5251, -0.1745, 0.0, 0.4768, 0.8731, -0.1745]
+      velocities: [0.0, -0.2023, -0.0, -0.0, 0.0, 0.4555, 0.2333, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 750000000
+    - 
+      positions: [0.0, 0.3062, 0.4462, -0.1745, 0.0, 0.5558, 0.9003, -0.1745]
+      velocities: [0.0, -0.247, -0.4794, 0.0, 0.0, 0.0, -0.0818, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  50000000
+    - 
+      positions: [0.0, 0.2678, 0.3626, -0.1745, 0.0, 0.5458, 0.8668, -0.1745]
+      velocities: [0.0, -0.2611, -0.6091, 0.0, 0.0, -0.131, -0.3491, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+    - 
+      positions: [0.0, 0.1869, 0.1692, -0.1745, 0.0, 0.4706, 0.7326, -0.1745]
+      velocities: [0.0, -0.2728, -0.6206, -0.0, 0.0, -0.3457, -0.5418, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.0673, 0.0, -0.1745, 0.0, 0.273, 0.4539, -0.1745]
+      velocities: [0.0, -0.2492, 0.0, 0.0, 0.0, -0.4911, -0.6515, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 950000000
+    - 
+      positions: [0.0, -0.0403, 0.0, -0.1745, 0.0, 0.0341, 0.1485, -0.1745]
+      velocities: [0.0, -0.1626, 0.0, 0.0, -0.0, -0.3993, -0.4956, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 464900000
+    - 
+      positions: [0.0, -0.0631, 0.0, -0.1745, 0.0, -0.0232, 0.078, -0.1745]
+      velocities: [-0.0, -0.1224, 0.0, 0.0, 0.0, -0.3143, -0.3854, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 627500000
+    - 
+      positions: [0.0, -0.0873, 0.0, -0.1745, 0.0, -0.0873, 0.0, -0.1745]
+      velocities: [-0.0, -0.0, 0.0, -0.0, -0.0, -0.0, -0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_slope_down/right_open/MV_RD_slopedown_rightopen_v3.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_slope_down/right_open/MV_RD_slopedown_rightopen_v3.subgait
@@ -1,0 +1,151 @@
+name: ''
+version: ''
+description: "The right open step for the ramp down with ankle -5."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 372500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 500000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 535100000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 900000000
+    joint_names: [right_knee, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 900300000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 100000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.0611, 0.2583, 0.0436, 0.0, -0.0933, 0.0, 0.0436]
+      velocities: [0.0, 0.6558, 1.1231, 0.0, 0.0, -0.027, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 372500000
+    - 
+      positions: [0.0, 0.1433, 0.3974, 0.0436, 0.0, -0.0968, 0.0, 0.0436]
+      velocities: [0.0, 0.6927, 1.1557, 0.0, 0.0, -0.0291, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.171, 0.4431, 0.0435, 0.0, -0.0979, 0.0, 0.0436]
+      velocities: [0.0, 0.6853, 1.1296, -0.0052, 0.0, -0.029, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 535100000
+    - 
+      positions: [0.0, 0.348, 0.6981, 0.0304, 0.0, -0.1061, 0.0, 0.0436]
+      velocities: [0.0, 0.1763, 0.0, -0.0614, 0.0, -0.0116, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 900000000
+    - 
+      positions: [0.0, 0.3491, 0.698, 0.0304, 0.0, -0.1061, 0.0, 0.0436]
+      velocities: [0.0, 0.1449, 0.0614, -0.0614, 0.0, -0.0116, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 900300000
+    - 
+      positions: [0.0, 0.4147, 0.4521, -0.0214, 0.0, -0.0873, 0.1364, 0.0436]
+      velocities: [0.0, 0.0794, -0.6227, -0.0982, 0.0, 0.0873, 0.4029, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4472, 0.1998, -0.0735, 0.0, 0.023, 0.4219, 0.0436]
+      velocities: [0.0, 0.0326, 0.0, -0.0638, 0.0, 0.2405, 0.4895, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 100000000
+    - 
+      positions: [0.0, 0.4558, 0.2026, -0.0873, 0.0, 0.116, 0.5976, 0.0436]
+      velocities: [0.0, 0.0125, 0.011, 0.0, 0.0, 0.2051, 0.3651, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.0873, 0.0, 0.1745, 0.6981, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_slope_down/right_open/MV_RD_slopedown_rightopen_v4.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_slope_down/right_open/MV_RD_slopedown_rightopen_v4.subgait
@@ -1,0 +1,151 @@
+name: ''
+version: ''
+description: "The right open step for the ramp down, with ankle -10."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 372500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 500000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 535100000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 900000000
+    joint_names: [right_knee, left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 900300000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 100000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.0611, 0.2583, 0.0436, 0.0, -0.0933, 0.0, 0.0436]
+      velocities: [0.0, 0.6558, 1.1231, 0.0, 0.0, -0.027, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 372500000
+    - 
+      positions: [0.0, 0.1433, 0.3974, 0.0436, 0.0, -0.0968, 0.0, 0.0436]
+      velocities: [0.0, 0.6927, 1.1557, 0.0, 0.0, -0.0291, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.171, 0.4431, 0.0434, 0.0, -0.0979, 0.0, 0.0436]
+      velocities: [0.0, 0.6853, 1.1296, -0.0086, 0.0, -0.029, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 535100000
+    - 
+      positions: [0.0, 0.348, 0.6981, 0.0216, 0.0, -0.1061, 0.0, 0.0436]
+      velocities: [0.0, 0.1763, 0.0, -0.1023, 0.0, -0.0116, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 900000000
+    - 
+      positions: [0.0, 0.3491, 0.698, 0.0216, 0.0, -0.1061, 0.0, 0.0436]
+      velocities: [0.0, 0.1449, 0.0614, -0.1023, 0.0, -0.0116, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 900300000
+    - 
+      positions: [0.0, 0.4147, 0.4521, -0.0646, 0.0, -0.0873, 0.1364, 0.0436]
+      velocities: [0.0, 0.0794, -0.6227, -0.1636, 0.0, 0.0873, 0.4029, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4472, 0.1998, -0.1515, 0.0, 0.023, 0.4219, 0.0436]
+      velocities: [0.0, 0.0326, 0.0, -0.1063, 0.0, 0.2405, 0.4895, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 100000000
+    - 
+      positions: [0.0, 0.4558, 0.2026, -0.1745, 0.0, 0.116, 0.5976, 0.0436]
+      velocities: [0.0, 0.0125, 0.011, 0.0, 0.0, 0.2051, 0.3651, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.1745, 0.0, 0.1745, 0.6981, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_slope_down/right_swing/MV_RD_slopedown_rightswing_v3.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_slope_down/right_swing/MV_RD_slopedown_rightswing_v3.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The right swing step for the ramp down, with ankle -5."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 372500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 535100000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 742900000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 907600000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 498799999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_ankle, left_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  59099999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.1745, 0.6981, -0.0873, 0.0, 0.4583, 0.2065, -0.0873]
+      velocities: [0.0, 0.0, -0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.2404, 0.8019, -0.0873, 0.0, 0.4463, 0.2288, -0.0873]
+      velocities: [0.0, 0.2872, 0.4195, 0.0, 0.0, -0.0608, 0.1154, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 372500000
+    - 
+      positions: [0.0, 0.2878, 0.8651, -0.0873, 0.0, 0.4347, 0.2512, -0.0873]
+      velocities: [0.0, 0.2906, 0.3462, 0.0, 0.0, -0.0822, 0.1599, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 535100000
+    - 
+      positions: [0.0, 0.3392, 0.9059, -0.0873, 0.0, 0.4148, 0.2908, -0.0873]
+      velocities: [0.0, 0.1817, -0.0, 0.0, 0.0, -0.1052, 0.2126, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 742900000
+    - 
+      positions: [0.0, 0.355, 0.8771, -0.0873, 0.0, 0.3966, 0.328, -0.0873]
+      velocities: [0.0, 0.0, -0.3346, -0.0, 0.0, -0.119, 0.2484, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 907600000
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.0873, 0.0, 0.3171, 0.5089, -0.0873]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.3491, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 498799999
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.0873, 0.0, 0.3171, 0.5076, -0.0873]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.348, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4143, 0.1998, -0.0873, 0.0, 0.241, 0.6448, -0.0873]
+      velocities: [0.0, 0.0734, 0.0, 0.0, 0.0, -0.1227, 0.1528, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  59099999
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.0873, 0.0, 0.1745, 0.6981, -0.0873]
+      velocities: [0.0, -0.0, -0.0, 0.0, 0.0, 0.0, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/test_versions-v/ramp_door_slope_down/right_swing/MV_RD_slopedown_rightswing_v4.subgait
+++ b/march_gait_files/test_versions-v/ramp_door_slope_down/right_swing/MV_RD_slopedown_rightswing_v4.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "The right swing step for the ramp down, with ankle -10."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 372500000
+    joint_names: [right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 535100000
+    joint_names: [left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 742900000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 907600000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 498799999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_ankle, left_ankle]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  59099999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.1745, 0.6981, -0.1745, 0.0, 0.4583, 0.2065, -0.1745]
+      velocities: [0.0, 0.0, -0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.2404, 0.8019, -0.1745, 0.0, 0.4463, 0.2288, -0.1745]
+      velocities: [0.0, 0.2872, 0.4195, 0.0, 0.0, -0.0608, 0.1154, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 372500000
+    - 
+      positions: [0.0, 0.2878, 0.8651, -0.1745, 0.0, 0.4347, 0.2512, -0.1745]
+      velocities: [0.0, 0.2906, 0.3462, 0.0, 0.0, -0.0822, 0.1599, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 535100000
+    - 
+      positions: [0.0, 0.3392, 0.9059, -0.1745, 0.0, 0.4148, 0.2908, -0.1745]
+      velocities: [0.0, 0.1817, -0.0, -0.0, 0.0, -0.1052, 0.2126, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 742900000
+    - 
+      positions: [0.0, 0.355, 0.8771, -0.1745, 0.0, 0.3966, 0.328, -0.1745]
+      velocities: [0.0, 0.0, -0.3346, 0.0, 0.0, -0.119, 0.2484, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 907600000
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.1745, 0.0, 0.3171, 0.5089, -0.1745]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.3491, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 498799999
+    - 
+      positions: [0.0, 0.3749, 0.4777, -0.1745, 0.0, 0.3171, 0.5076, -0.1745]
+      velocities: [0.0, 0.0595, -0.79, 0.0, 0.0, -0.1419, 0.348, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4143, 0.1998, -0.1745, 0.0, 0.241, 0.6448, -0.1745]
+      velocities: [0.0, 0.0734, 0.0, 0.0, 0.0, -0.1227, 0.1528, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  59099999
+    - 
+      positions: [0.0, 0.4583, 0.2065, -0.1745, 0.0, 0.1745, 0.6981, -0.1745]
+      velocities: [0.0, -0.0, -0.0, 0.0, 0.0, 0.0, -0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
--> Added new versions of the slope down gait for the Ramp and Door. One with ankle angle -5 and one with angle -10 (original is -15). With this gaits, we can test the ankle angle and make the angle gradually larger and not break everything immediately.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
--> New gait versions for Ramp and Door slope down and last step:
- v3: ankle angle -5 instead of -15.
- v4: ankle angle -10 instead of -15.

These gaits are both in test_versions-v and airgait-v.

<!-- Please don't forget to request for reviews -->
