### PR TITLE
Moved new gaits to training-v

### DIFF
--- a/march_gait_files/training-v/default.yaml
+++ b/march_gait_files/training-v/default.yaml
@@ -29,3 +29,8 @@ gaits:
   tilted_path_second_start: {left_open: MV_TPstart2_leftopen_v1, right_close: MV_TPstart2_rightclose_v1}
   tilted_path_first_end: {left_open: MV_TPend1_leftopen_v1, right_close: MV_TPend1_rightclose_v1}
   tilted_path_second_end: {left_open: MV_TPend2_leftopen_v1, right_close: MV_TPend2_rightclose_v1}
+  tilted_path_straight_start: {right_open: MV_TP_straightstart_rightopen_v1,
+                               left_close: MV_TP_straightstart_leftclose_v1}
+  tilted_path_single_step: {right_open: MV_TP_singlestep_rightopen_v1, left_close: MV_TP_singlestep_leftclose_v1}
+  tilted_path_straight_end: {left_open: MV_TP_straightend_leftopen_v1,
+                             right_close: MV_TP_straightend_rightclose_v1}

--- a/march_gait_files/training-v/tilted_path_single_step/left_close/MV_TP_singlestep_leftclose_v1.subgait
+++ b/march_gait_files/training-v/tilted_path_single_step/left_close/MV_TP_singlestep_leftclose_v1.subgait
@@ -1,0 +1,99 @@
+name: ''
+version: ''
+description: "Left close for the single step on the grass part of the Tilted Path."
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 496000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 581200000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 620000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 775000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 550000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.3316, 0.8378, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.6939, 1.2741, 0.0436, 0.0, 0.1381, 0.1062, 0.0436]
+      velocities: [0.0, 0.7185, 0.0, 0.0, 0.0, -0.3485, -0.1166, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 496000000
+    - 
+      positions: [0.0, 0.7383, 1.2652, 0.0436, 0.0, 0.1104, 0.0964, 0.0436]
+      velocities: [0.0, 0.404, -0.2105, -0.0, 0.0, -0.3388, -0.1255, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 581200000
+    - 
+      positions: [0.0, 0.7505, 1.2541, 0.0436, 0.0, 0.097, 0.0912, 0.0436]
+      velocities: [0.0, 0.1396, -0.3136, -0.0, 0.0, -0.3329, -0.1289, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 620000000
+    - 
+      positions: [0.0, 0.7397, 1.1744, 0.0436, 0.0, 0.0458, 0.0698, 0.0436]
+      velocities: [0.0, -0.2442, -0.6307, -0.0, 0.0, -0.3024, -0.1351, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 775000000
+    - 
+      positions: [0.0, 0.4014, 0.6981, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 550000000
+duration: 
+  secs: 1
+  nsecs: 550000000
+sounds: []

--- a/march_gait_files/training-v/tilted_path_single_step/right_open/MV_TP_singlestep_rightopen_v1.subgait
+++ b/march_gait_files/training-v/tilted_path_single_step/right_open/MV_TP_singlestep_rightopen_v1.subgait
@@ -1,0 +1,125 @@
+name: ''
+version: ''
+description: "The right open gait for the single step for the grass part of the Tilted Path."
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 562400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 750000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 900000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, 0.4014, 0.6981, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3269, 0.8374, 0.0436, 0.0, 0.3799, 0.7769, 0.0436]
+      velocities: [0.0, 1.01, 0.9344, -0.0, 0.0, -0.0648, 0.2043, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 562400000
+    - 
+      positions: [0.0, 0.3952, 0.8727, 0.0436, 0.0, 0.3752, 0.791, 0.0436]
+      velocities: [0.0, 0.9304, 0.0, -0.0, 0.0, -0.0677, 0.196, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [0.0, 0.4928, 0.8197, 0.0436, 0.0, 0.3669, 0.8128, 0.0436]
+      velocities: [0.0, 0.683, -0.8363, 0.0, 0.0, -0.0698, 0.1637, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 750000000
+    - 
+      positions: [0.0, 0.5585, 0.6333, 0.0436, 0.0, 0.3564, 0.8321, 0.0436]
+      velocities: [0.0, 0.1396, -1.4938, 0.0, 0.0, -0.0673, 0.0908, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 900000000
+    - 
+      positions: [0.0, 0.5513, 0.4416, 0.0436, 0.0, 0.3487, 0.8378, 0.0436]
+      velocities: [0.0, -0.2264, -1.6102, 0.0, 0.0, -0.0613, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [0.0, 0.3863, 0.0969, 0.0436, 0.0, 0.3336, 0.8378, 0.0436]
+      velocities: [0.0, -0.5711, 0.0, 0.0, 0.0, -0.026, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, 0.3316, 0.8378, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/training-v/tilted_path_single_step/tilted_path_single_step.gait
+++ b/march_gait_files/training-v/tilted_path_single_step/tilted_path_single_step.gait
@@ -1,0 +1,5 @@
+name: tilted_path_single_step
+
+graph:
+  from_subgait: [start,     right_open, left_close]
+  to_subgait:   [right_open, left_close, end]

--- a/march_gait_files/training-v/tilted_path_straight_end/left_open/MV_TP_straightend_leftopen_v1.subgait
+++ b/march_gait_files/training-v/tilted_path_straight_end/left_open/MV_TP_straightend_leftopen_v1.subgait
@@ -1,0 +1,112 @@
+name: ''
+version: ''
+description: "Ending step for Tilted Path straight, based on RT high step."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  12399999
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 176500000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 336500000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 466200000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, 0.4014, 0.6981, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.1308, 0.1959, 0.0436, 0.0, 0.7734, 1.4618, 0.0436]
+      velocities: [0.0, -0.0723, 0.3254, -0.0, 0.0, 0.3089, 0.2419, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  12399999
+    - 
+      positions: [0.0, -0.1436, 0.2532, 0.0436, 0.0, 0.8085, 1.4392, 0.0436]
+      velocities: [0.0, -0.0762, 0.3428, 0.0, 0.0, 0.1019, -0.5236, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 176500000
+    - 
+      positions: [0.0, -0.1559, 0.3089, 0.0436, 0.0, 0.8029, 1.3213, 0.0436]
+      velocities: [0.0, -0.0775, 0.349, 0.0, 0.0, -0.1745, -0.9303, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 336500000
+    - 
+      positions: [0.0, -0.1567, 0.3124, 0.0436, 0.0, 0.8014, 1.3118, 0.0436]
+      velocities: [0.0, -0.0776, 0.349, -0.0, 0.0, -0.1775, -0.9525, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, -0.2238, 0.6142, 0.0436, 0.0, 0.3093, 0.1396, 0.0436]
+      velocities: [0.0, -0.0257, 0.1156, 0.0, 0.0, -0.4715, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 466200000
+    - 
+      positions: [0.0, -0.2269, 0.6283, 0.0436, 0.0, 0.2094, 0.1396, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 700000000
+duration: 
+  secs: 2
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/training-v/tilted_path_straight_end/right_close/MV_TP_straightend_rightclose_v1.subgait
+++ b/march_gait_files/training-v/tilted_path_straight_end/right_close/MV_TP_straightend_rightclose_v1.subgait
@@ -1,0 +1,125 @@
+name: ''
+version: ''
+description: "Right close for ending step off the Tilted Path."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 700000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 873600000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  12399999
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 336500000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 665200000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.2269, 0.6283, 0.0436, 0.0, 0.2094, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3974, 1.309, 0.0436, 0.0, 0.0272, 0.1396, 0.0436]
+      velocities: [0.0, 1.2582, 0.5236, -0.0, 0.0, -0.1866, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 700000000
+    - 
+      positions: [0.0, 0.6084, 1.3715, 0.0436, 0.0, -0.0032, 0.1396, 0.0436]
+      velocities: [0.0, 1.0518, 0.2096, -0.0, 0.0, -0.1522, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 873600000
+    - 
+      positions: [0.0, 0.7266, 1.3823, 0.0436, 0.0, -0.0214, 0.1376, 0.0436]
+      velocities: [0.0, 0.7637, -0.024, -0.0, 0.0, -0.1295, -0.0293, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  12399999
+    - 
+      positions: [0.0, 0.7854, 1.2783, 0.0436, 0.0, -0.0556, 0.1174, 0.0436]
+      velocities: [0.0, -0.5236, -0.5781, 0.0, 0.0, -0.0802, -0.086, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 336500000
+    - 
+      positions: [0.0, 0.7809, 1.2723, 0.0436, 0.0, -0.0564, 0.1165, 0.0436]
+      velocities: [0.0, -0.5276, -0.594, -0.0, 0.0, -0.0789, -0.0872, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, 0.5659, 1.0013, 0.0436, 0.0, -0.075, 0.0847, 0.0436]
+      velocities: [0.0, -0.8056, -1.0821, 0.0, 0.0, -0.0435, -0.1121, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 665200000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 700000000
+duration: 
+  secs: 2
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/training-v/tilted_path_straight_end/tilted_path_straight_end.gait
+++ b/march_gait_files/training-v/tilted_path_straight_end/tilted_path_straight_end.gait
@@ -1,0 +1,5 @@
+name: tilted_path_straight_end
+
+graph:
+  from_subgait: [start,     left_open, right_close]
+  to_subgait:   [left_open, right_close, end]

--- a/march_gait_files/training-v/tilted_path_straight_start/left_close/MV_TP_straightstart_leftclose_v1.subgait
+++ b/march_gait_files/training-v/tilted_path_straight_start/left_close/MV_TP_straightstart_leftclose_v1.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "Left close for starting step TP, left knee ends in flexion."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 619100000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 700000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 873600000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  12399999
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 250000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 336500000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.3491, 0.1396, 0.0436, 0.0, -0.2269, 0.3491, 0.0436]
+      velocities: [0.0, -0.3491, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.1642, 0.1396, 0.0436, 0.0, 0.1537, 1.209, 0.0436]
+      velocities: [0.0, -0.2571, 0.0, 0.0, 0.0, 1.9984, 1.4018, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 619100000
+    - 
+      positions: [0.0, 0.144, 0.1396, 0.0436, 0.0, 0.295, 1.309, 0.0436]
+      velocities: [0.0, -0.2455, 0.0, -0.0, 0.0, 1.8577, 0.8727, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 700000000
+    - 
+      positions: [0.0, 0.1021, 0.1396, 0.0436, 0.0, 0.5903, 1.4107, 0.0436]
+      velocities: [0.0, -0.2199, 0.0, -0.0, 0.0, 1.4188, 0.3532, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 873600000
+    - 
+      positions: [0.0, 0.0747, 0.1376, 0.0436, 0.0, 0.7494, 1.4378, 0.0436]
+      velocities: [0.0, -0.2019, -0.0293, -0.0, 0.0, 1.0409, 0.1035, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  12399999
+    - 
+      positions: [0.0, 0.0302, 0.1247, 0.0436, 0.0, 0.8993, 1.4399, 0.0436]
+      velocities: [0.0, -0.1696, -0.0735, 0.0, 0.0, 0.2092, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 250000000
+    - 
+      positions: [0.0, 0.0154, 0.1174, 0.0436, 0.0, 0.9002, 1.4326, 0.0436]
+      velocities: [0.0, -0.1578, -0.086, 0.0, 0.0, -0.1745, -0.1599, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 336500000
+    - 
+      positions: [0.0, 0.0139, 0.1165, 0.0436, 0.0, 0.8987, 1.4308, 0.0436]
+      velocities: [0.0, -0.1565, -0.0872, -0.0, 0.0, -0.1779, -0.1786, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, 0.4014, 0.6981, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 700000000
+duration: 
+  secs: 2
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/training-v/tilted_path_straight_start/right_open/MV_TP_straightstart_rightopen_v1.subgait
+++ b/march_gait_files/training-v/tilted_path_straight_start/right_open/MV_TP_straightstart_rightopen_v1.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "This the right open for the Tilted Path, just a high step actually."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 619100000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  12399999
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 176500000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 336500000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 836000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 466200000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.1537, 0.7636, 0.0436, 0.0, -0.1056, 0.0362, 0.0436]
+      velocities: [0.0, 2.0, 1.833, 0.0, 0.0, -0.0541, 0.101, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 619100000
+    - 
+      positions: [0.0, 0.7495, 1.3552, 0.0436, 0.0, -0.1308, 0.0795, 0.0436]
+      velocities: [0.0, 1.0405, 0.9416, -0.0, 0.0, -0.0723, 0.1132, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  12399999
+    - 
+      positions: [0.0, 0.8767, 1.4392, 0.0436, 0.0, -0.1436, 0.0983, 0.0436]
+      velocities: [0.0, 0.4692, 0.0, 0.0, 0.0, -0.0762, 0.1055, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 176500000
+    - 
+      positions: [0.0, 0.9002, 1.3852, 0.0436, 0.0, -0.1559, 0.1141, 0.0436]
+      velocities: [0.0, -0.1745, -0.6337, 0.0, 0.0, -0.0775, 0.0911, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 336500000
+    - 
+      positions: [0.0, 0.8987, 1.3785, 0.0436, 0.0, -0.1567, 0.115, 0.0436]
+      velocities: [0.0, -0.1767, -0.6692, -0.0, 0.0, -0.0776, 0.09, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, 0.742, 0.7812, 0.0436, 0.0, -0.1925, 0.1396, 0.0436]
+      velocities: [0.0, -0.4325, -1.5115, 0.0, 0.0, -0.0681, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 836000000
+    - 
+      positions: [0.0, 0.4455, 0.1396, 0.0436, 0.0, -0.2238, 0.3093, 0.0436]
+      velocities: [0.0, -0.4439, 0.0, 0.0, 0.0, -0.0257, 0.2962, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 466200000
+    - 
+      positions: [0.0, 0.3491, 0.1396, 0.0436, 0.0, -0.2269, 0.3491, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 700000000
+duration: 
+  secs: 2
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/training-v/tilted_path_straight_start/tilted_path_straight_start.gait
+++ b/march_gait_files/training-v/tilted_path_straight_start/tilted_path_straight_start.gait
@@ -1,0 +1,5 @@
+name: tilted_path_straight_start
+
+graph:
+  from_subgait: [start,     right_open, left_close]
+  to_subgait:   [right_open, left_close, end]

--- a/march_gait_files/training-v/walk/left_close/MV_walk_leftclose_v3.subgait
+++ b/march_gait_files/training-v/walk/left_close/MV_walk_leftclose_v3.subgait
@@ -1,0 +1,112 @@
+name: ''
+version: ''
+description: "Final left step of the MIV walking gait, but then somewhat faster."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 416000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 487458064
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 520000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 650000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 780000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 300000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4698, 0.8727, 0.0436, 0.0, 0.1278, 0.1063, 0.0436]
+      velocities: [0.0, 1.4514, 0.0, 0.0, 0.0, -0.3573, -0.1388, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 416000000
+    - 
+      positions: [0.0, 0.544, 0.8581, 0.0436, 0.0, 0.1042, 0.096, 0.0436]
+      velocities: [0.0, 0.7097, -0.3902, 0.0, 0.0, -0.3162, -0.1499, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 487458064
+    - 
+      positions: [0.0, 0.5585, 0.8429, 0.0436, 0.0, 0.0951, 0.0914, 0.0436]
+      velocities: [0.0, 0.1396, -0.5571, -0.0, 0.0, -0.2948, -0.1535, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 520000000
+    - 
+      positions: [0.0, 0.5264, 0.7274, 0.0436, 0.0, 0.0644, 0.0706, 0.0436]
+      velocities: [0.0, -0.5826, -1.1203, -0.0, 0.0, -0.1754, -0.161, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 650000000
+    - 
+      positions: [0.0, 0.4116, 0.5564, 0.0436, 0.0, 0.0524, 0.0498, 0.0436]
+      velocities: [0.0, -1.0806, -1.4233, 0.0, 0.0, 0.0, -0.1555, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 780000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 300000000
+duration: 
+  secs: 1
+  nsecs: 300000000
+sounds: []

--- a/march_gait_files/training-v/walk/left_close/MV_walk_leftclose_v5.subgait
+++ b/march_gait_files/training-v/walk/left_close/MV_walk_leftclose_v5.subgait
@@ -1,0 +1,112 @@
+name: ''
+version: ''
+description: "Final left step of the MIV walking gait, but then somewhat faster."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 416000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 487500000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 520000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 650000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 780000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 300000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4698, 0.8727, 0.0436, 0.0, 0.1278, 0.1063, 0.0436]
+      velocities: [0.0, 1.4514, 0.0, 0.0, 0.0, -0.3573, -0.1388, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 416000000
+    - 
+      positions: [0.0, 0.544, 0.8581, 0.0436, 0.0, 0.1042, 0.096, 0.0436]
+      velocities: [0.0, 0.7097, -0.3902, 0.0, 0.0, -0.3162, -0.1499, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 487500000
+    - 
+      positions: [0.0, 0.5585, 0.8429, 0.0436, 0.0, 0.0951, 0.0914, 0.0436]
+      velocities: [0.0, 0.1396, -0.5571, -0.0, 0.0, -0.2948, -0.1535, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 520000000
+    - 
+      positions: [0.0, 0.5264, 0.7274, 0.0436, 0.0, 0.0644, 0.0706, 0.0436]
+      velocities: [0.0, -0.5826, -1.1203, -0.0, 0.0, -0.1754, -0.161, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 650000000
+    - 
+      positions: [0.0, 0.4116, 0.5564, 0.0436, 0.0, 0.0524, 0.0498, 0.0436]
+      velocities: [0.0, -1.0806, -1.4233, 0.0, 0.0, 0.0, -0.1555, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 780000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 300000000
+duration: 
+  secs: 1
+  nsecs: 300000000
+sounds: []

--- a/march_gait_files/training-v/walk/left_swing/MV_walk_leftswing_v5.subgait
+++ b/march_gait_files/training-v/walk/left_swing/MV_walk_leftswing_v5.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "MIV walking gait, swing 1 second, without ankle."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 199999999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 374999999
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 420000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 500000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 679999999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 899999999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0143, 0.4589, 0.0436, 0.0, 0.2004, 0.2094, 0.0436]
+      velocities: [0.0, 1.359, 2.5859, 0.0, 0.0, -0.5393, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 199999999
+    - 
+      positions: [0.0, 0.2671, 0.848, 0.0436, 0.0, 0.0938, 0.1886, 0.0436]
+      velocities: [0.0, 1.539, 1.1227, 0.0, 0.0, -0.6116, -0.1988, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 374999999
+    - 
+      positions: [0.0, 0.3266, 0.8727, 0.0436, 0.0, 0.069, 0.1801, 0.0436]
+      velocities: [0.0, 1.426, 0.0, 0.0, 0.0, -0.6126, -0.2145, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 420000000
+    - 
+      positions: [0.0, 0.4255, 0.8219, 0.0436, 0.0, 0.02, 0.1627, 0.0436]
+      velocities: [0.0, 1.0331, -1.2062, -0.0, 0.0, -0.5981, -0.2087, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4887, 0.6364, 0.0436, 0.0, -0.038, 0.1453, 0.0436]
+      velocities: [0.0, 0.1396, -2.2231, 0.0, 0.0, -0.5491, -0.1319, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.4805, 0.4442, 0.0436, 0.0, -0.0796, 0.1396, 0.0436]
+      velocities: [0.0, -0.2984, -2.4182, 0.0, 0.0, -0.4852, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 679999999
+    - 
+      positions: [0.0, 0.3423, 0.0969, 0.0436, 0.0, -0.1569, 0.1396, 0.0436]
+      velocities: [0.0, -0.6835, 0.0, 0.0, 0.0, -0.1964, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 899999999
+    - 
+      positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+duration: 
+  secs: 1
+  nsecs:         0
+sounds: []

--- a/march_gait_files/training-v/walk/right_close/MV_walk_rightclose_v3.subgait
+++ b/march_gait_files/training-v/walk/right_close/MV_walk_rightclose_v3.subgait
@@ -1,0 +1,112 @@
+name: ''
+version: ''
+description: "The MIV right close gait, but then somewhat faster."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 416000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 487458064
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 520000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 650000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 780000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 300000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4698, 0.8727, 0.0436, 0.0, 0.1278, 0.1063, 0.0436]
+      velocities: [0.0, 1.4514, 0.0, 0.0, 0.0, -0.3573, -0.1388, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 416000000
+    - 
+      positions: [0.0, 0.544, 0.8581, 0.0436, 0.0, 0.1042, 0.096, 0.0436]
+      velocities: [0.0, 0.7097, -0.3902, 0.0, 0.0, -0.3162, -0.1499, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 487458064
+    - 
+      positions: [0.0, 0.5585, 0.8429, 0.0436, 0.0, 0.0951, 0.0914, 0.0436]
+      velocities: [0.0, 0.1396, -0.5571, -0.0, 0.0, -0.2948, -0.1535, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 520000000
+    - 
+      positions: [0.0, 0.5264, 0.7274, 0.0436, 0.0, 0.0644, 0.0706, 0.0436]
+      velocities: [0.0, -0.5826, -1.1203, -0.0, 0.0, -0.1754, -0.161, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 650000000
+    - 
+      positions: [0.0, 0.4116, 0.5564, 0.0436, 0.0, 0.0524, 0.0498, 0.0436]
+      velocities: [0.0, -1.0806, -1.4233, 0.0, 0.0, 0.0, -0.1555, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 780000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 300000000
+duration: 
+  secs: 1
+  nsecs: 300000000
+sounds: []

--- a/march_gait_files/training-v/walk/right_close/MV_walk_rightclose_v5.subgait
+++ b/march_gait_files/training-v/walk/right_close/MV_walk_rightclose_v5.subgait
@@ -1,0 +1,112 @@
+name: ''
+version: ''
+description: "The MIV right close gait, but then somewhat faster."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 416000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 487500000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 520000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 650000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 780000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 300000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4698, 0.8727, 0.0436, 0.0, 0.1278, 0.1063, 0.0436]
+      velocities: [0.0, 1.4514, 0.0, 0.0, 0.0, -0.3573, -0.1388, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 416000000
+    - 
+      positions: [0.0, 0.544, 0.8581, 0.0436, 0.0, 0.1042, 0.096, 0.0436]
+      velocities: [0.0, 0.7097, -0.3902, 0.0, 0.0, -0.3162, -0.1499, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 487500000
+    - 
+      positions: [0.0, 0.5585, 0.8429, 0.0436, 0.0, 0.0951, 0.0914, 0.0436]
+      velocities: [0.0, 0.1396, -0.5571, -0.0, 0.0, -0.2948, -0.1535, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 520000000
+    - 
+      positions: [0.0, 0.5264, 0.7274, 0.0436, 0.0, 0.0644, 0.0706, 0.0436]
+      velocities: [0.0, -0.5826, -1.1203, -0.0, 0.0, -0.1754, -0.161, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 650000000
+    - 
+      positions: [0.0, 0.4116, 0.5564, 0.0436, 0.0, 0.0524, 0.0498, 0.0436]
+      velocities: [0.0, -1.0806, -1.4233, 0.0, 0.0, 0.0, -0.1555, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 780000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 300000000
+duration: 
+  secs: 1
+  nsecs: 300000000
+sounds: []

--- a/march_gait_files/training-v/walk/right_open/MV_walk_rightopen_v3.subgait
+++ b/march_gait_files/training-v/walk/right_open/MV_walk_rightopen_v3.subgait
@@ -1,0 +1,125 @@
+name: ''
+version: ''
+description: "The MIV right open gait, but then somewhat faster."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 487413333
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 546000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 650000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 780000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 884000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 170000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 300000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.2866, 0.8412, 0.0436, 0.0, -0.1121, 0.0797, 0.0436]
+      velocities: [0.0, 1.0367, 1.0363, 0.0, 0.0, -0.0852, 0.2352, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 487413333
+    - 
+      positions: [0.0, 0.3466, 0.8727, 0.0436, 0.0, -0.1174, 0.0936, 0.0436]
+      velocities: [0.0, 0.9527, 0.0, -0.0, 0.0, -0.0889, 0.2254, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 546000000
+    - 
+      positions: [0.0, 0.43, 0.8204, 0.0436, 0.0, -0.1265, 0.1145, 0.0436]
+      velocities: [0.0, 0.7056, -0.9536, -0.0, 0.0, -0.0916, 0.1894, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 650000000
+    - 
+      positions: [0.0, 0.4887, 0.6343, 0.0436, 0.0, -0.1384, 0.1339, 0.0436]
+      velocities: [0.0, 0.1396, -1.7195, 0.0, 0.0, -0.0884, 0.1057, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 780000000
+    - 
+      positions: [0.0, 0.4845, 0.4499, 0.0436, 0.0, -0.1469, 0.1396, 0.0436]
+      velocities: [0.0, -0.1916, -1.8611, 0.0, 0.0, -0.081, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 884000000
+    - 
+      positions: [0.0, 0.3488, 0.0969, 0.0436, 0.0, -0.1644, 0.1396, 0.0436]
+      velocities: [0.0, -0.5471, 0.0, 0.0, 0.0, -0.0343, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 170000000
+    - 
+      positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 300000000
+duration: 
+  secs: 1
+  nsecs: 300000000
+sounds: []

--- a/march_gait_files/training-v/walk/right_open/MV_walk_rightopen_v5.subgait
+++ b/march_gait_files/training-v/walk/right_open/MV_walk_rightopen_v5.subgait
@@ -1,0 +1,125 @@
+name: ''
+version: ''
+description: "The MIV right open gait, but then somewhat faster."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 487400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 546000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 650000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 780000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 884000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 169999999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 300000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.2866, 0.8412, 0.0436, 0.0, -0.1121, 0.0797, 0.0436]
+      velocities: [0.0, 1.0367, 1.0363, 0.0, 0.0, -0.0852, 0.2352, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 487400000
+    - 
+      positions: [0.0, 0.3466, 0.8727, 0.0436, 0.0, -0.1174, 0.0936, 0.0436]
+      velocities: [0.0, 0.9527, 0.0, -0.0, 0.0, -0.0889, 0.2254, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 546000000
+    - 
+      positions: [0.0, 0.43, 0.8204, 0.0436, 0.0, -0.1265, 0.1145, 0.0436]
+      velocities: [0.0, 0.7056, -0.9536, -0.0, 0.0, -0.0916, 0.1894, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 650000000
+    - 
+      positions: [0.0, 0.4887, 0.6343, 0.0436, 0.0, -0.1384, 0.1339, 0.0436]
+      velocities: [0.0, 0.1396, -1.7195, 0.0, 0.0, -0.0884, 0.1057, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 780000000
+    - 
+      positions: [0.0, 0.4845, 0.4499, 0.0436, 0.0, -0.1469, 0.1396, 0.0436]
+      velocities: [0.0, -0.1916, -1.8611, 0.0, 0.0, -0.081, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 884000000
+    - 
+      positions: [0.0, 0.3488, 0.0969, 0.0436, 0.0, -0.1644, 0.1396, 0.0436]
+      velocities: [0.0, -0.5471, 0.0, 0.0, 0.0, -0.0343, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 169999999
+    - 
+      positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 300000000
+duration: 
+  secs: 1
+  nsecs: 300000000
+sounds: []

--- a/march_gait_files/training-v/walk/right_swing/MV_walk_rightswing_v5.subgait
+++ b/march_gait_files/training-v/walk/right_swing/MV_walk_rightswing_v5.subgait
@@ -1,0 +1,138 @@
+name: ''
+version: ''
+description: "MIV walking gait, swing 1 second, without ankle."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 199999999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 374999999
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 420000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 500000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 600000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 679999999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 899999999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0143, 0.4589, 0.0436, 0.0, 0.2004, 0.2094, 0.0436]
+      velocities: [0.0, 1.359, 2.5859, 0.0, 0.0, -0.5393, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 199999999
+    - 
+      positions: [0.0, 0.2671, 0.848, 0.0436, 0.0, 0.0938, 0.1886, 0.0436]
+      velocities: [0.0, 1.539, 1.1227, 0.0, 0.0, -0.6116, -0.1988, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 374999999
+    - 
+      positions: [0.0, 0.3266, 0.8727, 0.0436, 0.0, 0.069, 0.1801, 0.0436]
+      velocities: [0.0, 1.426, 0.0, 0.0, 0.0, -0.6126, -0.2145, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 420000000
+    - 
+      positions: [0.0, 0.4255, 0.8219, 0.0436, 0.0, 0.02, 0.1627, 0.0436]
+      velocities: [0.0, 1.0331, -1.2062, -0.0, 0.0, -0.5981, -0.2087, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4887, 0.6364, 0.0436, 0.0, -0.038, 0.1453, 0.0436]
+      velocities: [0.0, 0.1396, -2.2231, 0.0, 0.0, -0.5491, -0.1319, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 600000000
+    - 
+      positions: [0.0, 0.4805, 0.4442, 0.0436, 0.0, -0.0796, 0.1396, 0.0436]
+      velocities: [0.0, -0.2984, -2.4182, 0.0, 0.0, -0.4852, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 679999999
+    - 
+      positions: [0.0, 0.3423, 0.0969, 0.0436, 0.0, -0.1569, 0.1396, 0.0436]
+      velocities: [0.0, -0.6835, 0.0, 0.0, 0.0, -0.1964, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 899999999
+    - 
+      positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+duration: 
+  secs: 1
+  nsecs:         0
+sounds: []


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
--> After the groundgaiting session we had this morning, I moved the new forward Tilted Path gaits to training-v so they can be trained with Sjaan. I did the same with the new - faster - walking gait. For the latter one: I did not set this one as default. We can try it first during a training and we can set it as default afterwards.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
--> New gaits are now in training-v as well.

<!-- Please don't forget to request for reviews -->
