### PR TITLE
New stairs gait version, adjusted high step

### DIFF
--- a/march_gait_files/airgait-v/default.yaml
+++ b/march_gait_files/airgait-v/default.yaml
@@ -7,7 +7,7 @@ gaits:
                          right_swing: MV_RD_slopedown_rightswing_v1, left_swing: MV_RD_slopedown_leftswing_v1,
                          right_close: MV_RD_slopedown_rightclose_v1, left_close: MV_RD_slopedown_leftclose_v1}
   ramp_door_last_step: {right_open: MV_RD_laststep_rightopen_v2, left_close: MV_RD_laststep_leftclose_v2}
-  rough_terrain_high_step: {right_open: MV_RT_highstep_rightopen_v6, left_close: MV_RT_highstep_leftclose_v8}
+  rough_terrain_high_step: {right_open: MV_RT_highstep_rightopen_v7, left_close: MV_RT_highstep_leftclose_v8}
   rough_terrain_middle_steps: {right_open: MV_RT_middlestep_rightopen_v2, left_swing: MV_RT_middlestep_leftswing_v2,
                                right_swing: MV_RT_middlestep_rightswing_v2, left_close: MV_RT_middlestep_leftclose_v3}
   rough_terrain_first_middle_step: {right_open: MV_RT_first_middlestep_rightopen_v2,
@@ -25,7 +25,7 @@ gaits:
   tilted_path_second_start: {left_open: MV_TPstart2_leftopen_v1, right_close: MV_TPstart2_rightclose_v1}
   tilted_path_first_end: {left_open: MV_TPend1_leftopen_v1, right_close: MV_TPend1_rightclose_v1}
   tilted_path_second_end: {left_open: MV_TPend2_leftopen_v1, right_close: MV_TPend2_rightclose_v1}
-  tilted_path_straight_start: {right_open: MV_TP_straightstart_rightopen_v1,
+  tilted_path_straight_start: {right_open: MV_TP_straightstart_rightopen_v2,
                                left_close: MV_TP_straightstart_leftclose_v1}
   tilted_path_single_step: {right_open: MV_TP_singlestep_rightopen_v1, left_close: MV_TP_singlestep_leftclose_v1}
   tilted_path_straight_end: {left_open: MV_TP_straightend_leftopen_v1,

--- a/march_gait_files/airgait-v/default.yaml
+++ b/march_gait_files/airgait-v/default.yaml
@@ -30,9 +30,9 @@ gaits:
   tilted_path_single_step: {right_open: MV_TP_singlestep_rightopen_v1, left_close: MV_TP_singlestep_leftclose_v1}
   tilted_path_straight_end: {left_open: MV_TP_straightend_leftopen_v1,
                              right_close: MV_TP_straightend_rightclose_v1}
-  stairs_up: {right_open: MIV_final, left_swing: MIV_final,
-              right_swing: MIV_final, left_close: MIV_final,
-              right_close: MIV_final}
+  stairs_up: {right_open: MV_stairsup_rightopen_v5, left_swing: MV_stairsup_leftswing_v5,
+              right_swing: MV_stairsup_rightswing_v5, left_close: MV_stairsup_leftclose_v5,
+              right_close: MV_stairsup_rightclose_v5}
   stairs_down: {right_open: MIV_final, left_swing: MIV_final,
                 right_swing: MIV_final, left_close: MIV_final,
                 right_close: MIV_final}

--- a/march_gait_files/airgait-v/rough_terrain_high_step/right_open/MV_RT_highstep_rightopen_v7.subgait
+++ b/march_gait_files/airgait-v/rough_terrain_high_step/right_open/MV_RT_highstep_rightopen_v7.subgait
@@ -1,0 +1,138 @@
+name: !!python/unicode "right_open"
+version: "MV_RT_highstep_rightopen_v7"
+description: "A little lower velocity in the hip."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 619100000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  12399999
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 176500000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 336500000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 836000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 466200000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.1537, 0.7636, 0.0436, 0.0, -0.1056, 0.0362, 0.0436]
+      velocities: [0.0, 1.3963, 1.8319, 0.0, 0.0, -0.0544, 0.1014, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 619100000
+    - 
+      positions: [0.0, 0.6996, 1.3552, 0.0436, 0.0, -0.1308, 0.0795, 0.0436]
+      velocities: [0.0, 1.1953, 0.9196, 0.0, 0.0, -0.0725, 0.1131, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  12399999
+    - 
+      positions: [0.0, 0.8596, 1.4392, 0.0436, 0.0, -0.1436, 0.0983, 0.0436]
+      velocities: [0.0, 0.6315, 0.0, 0.0, 0.0, -0.0762, 0.1052, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 176500000
+    - 
+      positions: [0.0, 0.9002, 1.3852, 0.0436, 0.0, -0.1559, 0.1141, 0.0436]
+      velocities: [0.0, -0.1745, -0.6515, 0.0, 0.0, -0.0775, 0.0905, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 336500000
+    - 
+      positions: [0.0, 0.8987, 1.3785, 0.0436, 0.0, -0.1567, 0.115, 0.0436]
+      velocities: [0.0, -0.1809, -0.6867, 0.0, 0.0, -0.0776, 0.0894, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, 0.742, 0.7812, 0.0436, 0.0, -0.1925, 0.1396, 0.0436]
+      velocities: [0.0, -0.434, -1.5114, 0.0, 0.0, -0.0679, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 836000000
+    - 
+      positions: [0.0, 0.4455, 0.1396, 0.0436, 0.0, -0.2238, 0.3093, 0.0436]
+      velocities: [0.0, -0.4425, 0.0, 0.0, 0.0, -0.0252, 0.2925, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 466200000
+    - 
+      positions: [0.0, 0.3491, 0.1396, 0.0436, 0.0, -0.2269, 0.3491, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 700000000
+duration: 
+  secs: 2
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/airgait-v/rough_terrain_high_step/right_open/MV_RT_highstep_rightopen_v7.subgait
+++ b/march_gait_files/airgait-v/rough_terrain_high_step/right_open/MV_RT_highstep_rightopen_v7.subgait
@@ -1,4 +1,4 @@
-name: !!python/unicode "right_open"
+name: "right_open"
 version: "MV_RT_highstep_rightopen_v7"
 description: "A little lower velocity in the hip."
 gait_type: "walk_like"

--- a/march_gait_files/airgait-v/stairs_up/left_close/MV_stairsup_leftclose_v5.subgait
+++ b/march_gait_files/airgait-v/stairs_up/left_close/MV_stairsup_leftclose_v5.subgait
@@ -1,0 +1,73 @@
+name: "left_close"
+version: "MV_stairsup_leftclose_v5"
+description: "Stairs up with higher steps."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 527300000
+    joint_names: [left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  59600000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.2269, 0.2443, 0.0436, 0.0, 1.1694, 1.1345, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.9599, 1.4835, 0.0436, 0.0, 0.5253, 0.553, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.6282, -0.5671, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 527300000
+    - 
+      positions: [0.0, 0.6511, 1.2008, 0.0436, 0.0, 0.2072, 0.2659, 0.0436]
+      velocities: [0.0, -0.9825, -1.3331, 0.0, 0.0, -0.5418, -0.4891, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  59600000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up/left_swing/MV_stairsup_leftswing_v5.subgait
+++ b/march_gait_files/airgait-v/stairs_up/left_swing/MV_stairsup_leftswing_v5.subgait
@@ -1,0 +1,86 @@
+name: "left_swing"
+version: "MV_stairsup_leftswing_v5"
+description: "Stairs up with higher steps."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 527300000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 490000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.2269, 0.2443, 0.0436, 0.0, 1.1694, 1.1345, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 1.2117, 1.7453, 0.0436, 0.0, 0.7904, 0.6676, 0.0436]
+      velocities: [0.0, 0.6411, 0.0, 0.0, 0.0, -0.5076, -0.5983, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+    - 
+      positions: [0.0, 1.309, 1.6927, 0.0436, 0.0, 0.6198, 0.472, 0.0436]
+      velocities: [0.0, -0.1222, -0.3013, 0.0, 0.0, -0.5132, -0.569, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 527300000
+    - 
+      positions: [0.0, 1.1941, 1.2545, 0.0436, 0.0, 0.2384, 0.1396, 0.0436]
+      velocities: [0.0, -0.0883, -0.4143, 0.0, 0.0, -0.196, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 490000000
+    - 
+      positions: [0.0, 1.1694, 1.1345, 0.0436, 0.0, 0.2269, 0.2443, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.1745, 0.6981, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up/right_close/MV_stairsup_rightclose_v5.subgait
+++ b/march_gait_files/airgait-v/stairs_up/right_close/MV_stairsup_rightclose_v5.subgait
@@ -1,0 +1,73 @@
+name: "right_close"
+version: "MV_stairsup_rightclose_v5"
+description: "Stairs up with higher steps."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 527300000
+    joint_names: [right_hip_fe, right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  59600000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 1.1694, 1.1345, 0.0436, 0.0, 0.2269, 0.2443, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.1745, 0.6981, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.5253, 0.553, 0.0436, 0.0, 0.9599, 1.4835, 0.0436]
+      velocities: [0.0, -0.6282, -0.5671, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 527300000
+    - 
+      positions: [0.0, 0.2072, 0.2659, 0.0436, 0.0, 0.6511, 1.2008, 0.0436]
+      velocities: [0.0, -0.5418, -0.4891, 0.0, 0.0, -0.9825, -1.3331, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  59600000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up/right_open/MV_stairsup_rightopen_v5.subgait
+++ b/march_gait_files/airgait-v/stairs_up/right_open/MV_stairsup_rightopen_v5.subgait
@@ -1,0 +1,86 @@
+name: "right_open"
+version: "MV_stairsup_rightopen_v5"
+description: "Stairs up with higher step and somewhat slower."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 527300000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 490000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0275, 0.0655, 0.0436, 0.0, 1.1634, 1.7453, 0.0436]
+      velocities: [0.0, 0.0946, 0.084, 0.0, 0.0, 0.9029, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+    - 
+      positions: [0.0, 0.0072, 0.093, 0.0436, 0.0, 1.309, 1.6927, 0.0436]
+      velocities: [0.0, 0.1149, 0.0798, 0.0, 0.0, -0.1222, -0.3013, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 527300000
+    - 
+      positions: [0.0, 0.1412, 0.1396, 0.0436, 0.0, 1.1941, 1.2545, 0.0436]
+      velocities: [0.0, 0.1596, 0.0, 0.0, 0.0, -0.0883, -0.4143, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 490000000
+    - 
+      positions: [0.0, 0.2269, 0.2443, 0.0436, 0.0, 1.1694, 1.1345, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up/right_swing/MV_stairsup_rightswing_v5.subgait
+++ b/march_gait_files/airgait-v/stairs_up/right_swing/MV_stairsup_rightswing_v5.subgait
@@ -1,0 +1,86 @@
+name: "right_swing"
+version: "MV_stairsup_rightswing_v5"
+description: "Stairs up with higher steps."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 527300000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 490000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 1.1694, 1.1345, 0.0436, 0.0, 0.2269, 0.2443, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.1745, 0.6981, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.7904, 0.6676, 0.0436, 0.0, 1.2117, 1.7453, 0.0436]
+      velocities: [0.0, -0.5076, -0.5983, 0.0, 0.0, 0.6411, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+    - 
+      positions: [0.0, 0.6198, 0.472, 0.0436, 0.0, 1.309, 1.6927, 0.0436]
+      velocities: [0.0, -0.5132, -0.569, 0.0, 0.0, -0.1222, -0.3013, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 527300000
+    - 
+      positions: [0.0, 0.2384, 0.1396, 0.0436, 0.0, 1.1941, 1.2545, 0.0436]
+      velocities: [0.0, -0.196, 0.0, 0.0, 0.0, -0.0883, -0.4143, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 490000000
+    - 
+      positions: [0.0, 0.2269, 0.2443, 0.0436, 0.0, 1.1694, 1.1345, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/tilted_path_straight_start/right_open/MV_TP_straightstart_rightopen_v2.subgait
+++ b/march_gait_files/airgait-v/tilted_path_straight_start/right_open/MV_TP_straightstart_rightopen_v2.subgait
@@ -1,0 +1,138 @@
+name: "right_open"
+version: "MV_TP_straightstart_rightopen_v2"
+description: "A little lower velocity in the hip."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 619100000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  12399999
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 176500000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 336500000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 836000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 466200000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 700000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.1537, 0.7636, 0.0436, 0.0, -0.1056, 0.0362, 0.0436]
+      velocities: [0.0, 1.3963, 1.8319, 0.0, 0.0, -0.0544, 0.1014, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 619100000
+    - 
+      positions: [0.0, 0.6996, 1.3552, 0.0436, 0.0, -0.1308, 0.0795, 0.0436]
+      velocities: [0.0, 1.1953, 0.9196, 0.0, 0.0, -0.0725, 0.1131, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  12399999
+    - 
+      positions: [0.0, 0.8596, 1.4392, 0.0436, 0.0, -0.1436, 0.0983, 0.0436]
+      velocities: [0.0, 0.6315, 0.0, 0.0, 0.0, -0.0762, 0.1052, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 176500000
+    - 
+      positions: [0.0, 0.9002, 1.3852, 0.0436, 0.0, -0.1559, 0.1141, 0.0436]
+      velocities: [0.0, -0.1745, -0.6515, 0.0, 0.0, -0.0775, 0.0905, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 336500000
+    - 
+      positions: [0.0, 0.8987, 1.3785, 0.0436, 0.0, -0.1567, 0.115, 0.0436]
+      velocities: [0.0, -0.1809, -0.6867, 0.0, 0.0, -0.0776, 0.0894, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, 0.742, 0.7812, 0.0436, 0.0, -0.1925, 0.1396, 0.0436]
+      velocities: [0.0, -0.434, -1.5114, 0.0, 0.0, -0.0679, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 836000000
+    - 
+      positions: [0.0, 0.4455, 0.1396, 0.0436, 0.0, -0.2238, 0.3093, 0.0436]
+      velocities: [0.0, -0.4425, 0.0, 0.0, 0.0, -0.0252, 0.2925, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 466200000
+    - 
+      positions: [0.0, 0.3491, 0.1396, 0.0436, 0.0, -0.2269, 0.3491, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 700000000
+duration: 
+  secs: 2
+  nsecs: 700000000
+sounds: []

--- a/march_gait_files/test_versions-v/default.yaml
+++ b/march_gait_files/test_versions-v/default.yaml
@@ -31,9 +31,9 @@ gaits:
   tilted_path_second_end: {left_open: MV_TPend2_leftopen_v1, right_close: MV_TPend2_rightclose_v1}
   tilted_path_straight_start_right: {right_open: MV_TPstraight_rightopen_v1, left_close: MV_TPstraight_leftclose_v1}
   tilted_path_straight_start_left: {left_open: MV_TPstraight_leftopen_v1, right_close: MV_TPstraight_rightclose_v1}
-  stairs_up: {right_open: MV_stairsup_rightopen_v2, left_swing: MV_stairsup_leftswing_v2,
-              right_swing: MV_stairsup_rightswing_v2, left_close: MV_stairsup_leftclose_v2,
-              right_close: MV_stairsup_rightclose_v2}
+  stairs_up: {right_open: MV_stairsup_rightopen_v5, left_swing: MV_stairsup_leftswing_v5,
+              right_swing: MV_stairsup_rightswing_v5, left_close: MV_stairsup_leftclose_v5,
+              right_close: MV_stairsup_rightclose_v5}
   stairs_down: {right_open: MV_stairsdown_rightopen_v2, left_swing: MV_stairsdown_leftswing_v2,
               right_swing: MV_stairsdown_rightswing_v2, left_close: MV_stairsdown_leftclose_v2,
               right_close: MV_stairsdown_rightclose_v2}

--- a/march_gait_files/test_versions-v/stairs_up/left_close/MV_stairsup_leftclose_v5.subgait
+++ b/march_gait_files/test_versions-v/stairs_up/left_close/MV_stairsup_leftclose_v5.subgait
@@ -12,22 +12,17 @@ setpoints:
   - 
     time_from_start: 
       secs: 1
-      nsecs: 399999999
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 700000000
-    joint_names: [left_hip_fe]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 887999999
-    joint_names: [left_knee]
+      nsecs: 527300000
+    joint_names: [left_hip_fe, left_knee]
   - 
     time_from_start: 
       secs: 2
-      nsecs: 750000000
+      nsecs:  59600000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
     joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
   right_ankle]
 trajectory: 
@@ -49,38 +44,30 @@ trajectory:
         secs: 0
         nsecs:         0
     - 
-      positions: [0.0, 0.9054, 1.4835, 0.0436, 0.0, 0.5273, 0.5548, 0.0436]
-      velocities: [0.0, 0.335, 0.0, 0.0, 0.0, -0.6853, -0.6187, 0.0]
+      positions: [0.0, 0.9599, 1.4835, 0.0436, 0.0, 0.5253, 0.553, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.6282, -0.5671, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
         secs: 1
-        nsecs: 399999999
+        nsecs: 527300000
     - 
-      positions: [0.0, 0.9599, 1.3917, 0.0436, 0.0, 0.3249, 0.3721, 0.0436]
-      velocities: [0.0, 0.0, -0.6842, 0.0, 0.0, -0.6481, -0.5851, 0.0]
+      positions: [0.0, 0.6511, 1.2008, 0.0436, 0.0, 0.2072, 0.2659, 0.0436]
+      velocities: [0.0, -0.9825, -1.3331, 0.0, 0.0, -0.5418, -0.4891, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
-        secs: 1
-        nsecs: 700000000
-    - 
-      positions: [0.0, 0.8722, 1.2008, 0.0436, 0.0, 0.2064, 0.2651, 0.0436]
-      velocities: [0.0, -0.8754, -1.3331, 0.0, 0.0, -0.5905, -0.5331, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 887999999
+        secs: 2
+        nsecs:  59600000
     - 
       positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
       velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
-        secs: 2
-        nsecs: 750000000
+        secs: 3
+        nsecs:         0
 duration: 
-  secs: 2
-  nsecs: 750000000
+  secs: 3
+  nsecs:         0
 sounds: []

--- a/march_gait_files/test_versions-v/stairs_up/left_close/MV_stairsup_leftclose_v5.subgait
+++ b/march_gait_files/test_versions-v/stairs_up/left_close/MV_stairsup_leftclose_v5.subgait
@@ -1,0 +1,86 @@
+name: "left_close"
+version: "MV_stairsup_leftclose_v5"
+description: "Stairs up with higher steps."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 399999999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 700000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 887999999
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 750000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.2269, 0.2443, 0.0436, 0.0, 1.1694, 1.1345, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.9054, 1.4835, 0.0436, 0.0, 0.5273, 0.5548, 0.0436]
+      velocities: [0.0, 0.335, 0.0, 0.0, 0.0, -0.6853, -0.6187, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 399999999
+    - 
+      positions: [0.0, 0.9599, 1.3917, 0.0436, 0.0, 0.3249, 0.3721, 0.0436]
+      velocities: [0.0, 0.0, -0.6842, 0.0, 0.0, -0.6481, -0.5851, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 700000000
+    - 
+      positions: [0.0, 0.8722, 1.2008, 0.0436, 0.0, 0.2064, 0.2651, 0.0436]
+      velocities: [0.0, -0.8754, -1.3331, 0.0, 0.0, -0.5905, -0.5331, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 887999999
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 750000000
+duration: 
+  secs: 2
+  nsecs: 750000000
+sounds: []

--- a/march_gait_files/test_versions-v/stairs_up/left_swing/MV_stairsup_leftswing_v5.subgait
+++ b/march_gait_files/test_versions-v/stairs_up/left_swing/MV_stairsup_leftswing_v5.subgait
@@ -1,0 +1,86 @@
+name: "left_swing"
+version: "MV_stairsup_leftswing_v5"
+description: "Stairs up with higher steps."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 100000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 800000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 282500000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 750000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.2269, 0.2443, 0.0436, 0.0, 1.1694, 1.1345, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 1.0014, 1.7453, 0.0436, 0.0, 0.7949, 0.6679, 0.0436]
+      velocities: [0.0, 0.8166, 0.0, 0.0, 0.0, -0.5486, -0.6527, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 100000000
+    - 
+      positions: [0.0, 1.309, 1.5107, 0.0436, 0.0, 0.4172, 0.2557, 0.0436]
+      velocities: [0.0, -0.1222, -0.5418, 0.0, 0.0, -0.4704, -0.4383, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 800000000
+    - 
+      positions: [0.0, 1.2241, 1.2557, 0.0436, 0.0, 0.2441, 0.1396, 0.0436]
+      velocities: [0.0, -0.1894, -0.4534, 0.0, 0.0, -0.2221, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 282500000
+    - 
+      positions: [0.0, 1.1694, 1.1345, 0.0436, 0.0, 0.2269, 0.2443, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.1745, 0.6981, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 750000000
+duration: 
+  secs: 2
+  nsecs: 750000000
+sounds: []

--- a/march_gait_files/test_versions-v/stairs_up/left_swing/MV_stairsup_leftswing_v5.subgait
+++ b/march_gait_files/test_versions-v/stairs_up/left_swing/MV_stairsup_leftswing_v5.subgait
@@ -12,22 +12,22 @@ setpoints:
   - 
     time_from_start: 
       secs: 1
-      nsecs: 100000000
+      nsecs: 199999999
     joint_names: [left_knee]
   - 
     time_from_start: 
       secs: 1
-      nsecs: 800000000
+      nsecs: 527300000
     joint_names: [left_hip_fe]
   - 
     time_from_start: 
       secs: 2
-      nsecs: 282500000
+      nsecs: 490000000
     joint_names: [right_knee]
   - 
     time_from_start: 
-      secs: 2
-      nsecs: 750000000
+      secs: 3
+      nsecs:         0
     joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
   right_ankle]
 trajectory: 
@@ -49,38 +49,38 @@ trajectory:
         secs: 0
         nsecs:         0
     - 
-      positions: [0.0, 1.0014, 1.7453, 0.0436, 0.0, 0.7949, 0.6679, 0.0436]
-      velocities: [0.0, 0.8166, 0.0, 0.0, 0.0, -0.5486, -0.6527, 0.0]
+      positions: [0.0, 1.2117, 1.7453, 0.0436, 0.0, 0.7904, 0.6676, 0.0436]
+      velocities: [0.0, 0.6411, 0.0, 0.0, 0.0, -0.5076, -0.5983, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
         secs: 1
-        nsecs: 100000000
+        nsecs: 199999999
     - 
-      positions: [0.0, 1.309, 1.5107, 0.0436, 0.0, 0.4172, 0.2557, 0.0436]
-      velocities: [0.0, -0.1222, -0.5418, 0.0, 0.0, -0.4704, -0.4383, 0.0]
+      positions: [0.0, 1.309, 1.6927, 0.0436, 0.0, 0.6198, 0.472, 0.0436]
+      velocities: [0.0, -0.1222, -0.3013, 0.0, 0.0, -0.5132, -0.569, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
         secs: 1
-        nsecs: 800000000
+        nsecs: 527300000
     - 
-      positions: [0.0, 1.2241, 1.2557, 0.0436, 0.0, 0.2441, 0.1396, 0.0436]
-      velocities: [0.0, -0.1894, -0.4534, 0.0, 0.0, -0.2221, 0.0, 0.0]
+      positions: [0.0, 1.1941, 1.2545, 0.0436, 0.0, 0.2384, 0.1396, 0.0436]
+      velocities: [0.0, -0.0883, -0.4143, 0.0, 0.0, -0.196, 0.0, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
         secs: 2
-        nsecs: 282500000
+        nsecs: 490000000
     - 
       positions: [0.0, 1.1694, 1.1345, 0.0436, 0.0, 0.2269, 0.2443, 0.0436]
       velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.1745, 0.6981, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
-        secs: 2
-        nsecs: 750000000
+        secs: 3
+        nsecs:         0
 duration: 
-  secs: 2
-  nsecs: 750000000
+  secs: 3
+  nsecs:         0
 sounds: []

--- a/march_gait_files/test_versions-v/stairs_up/right_close/MV_stairsup_rightclose_v5.subgait
+++ b/march_gait_files/test_versions-v/stairs_up/right_close/MV_stairsup_rightclose_v5.subgait
@@ -12,22 +12,17 @@ setpoints:
   - 
     time_from_start: 
       secs: 1
-      nsecs: 399999999
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 700000000
-    joint_names: [right_hip_fe]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 887999999
-    joint_names: [right_knee]
+      nsecs: 527300000
+    joint_names: [right_hip_fe, right_knee]
   - 
     time_from_start: 
       secs: 2
-      nsecs: 750000000
+      nsecs:  59600000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
     joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
   right_ankle]
 trajectory: 
@@ -49,38 +44,30 @@ trajectory:
         secs: 0
         nsecs:         0
     - 
-      positions: [0.0, 0.5273, 0.5548, 0.0436, 0.0, 0.9054, 1.4835, 0.0436]
-      velocities: [0.0, -0.6853, -0.6187, 0.0, 0.0, 0.335, 0.0, 0.0]
+      positions: [0.0, 0.5253, 0.553, 0.0436, 0.0, 0.9599, 1.4835, 0.0436]
+      velocities: [0.0, -0.6282, -0.5671, 0.0, 0.0, 0.0, 0.0, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
         secs: 1
-        nsecs: 399999999
+        nsecs: 527300000
     - 
-      positions: [0.0, 0.3249, 0.3721, 0.0436, 0.0, 0.9599, 1.3917, 0.0436]
-      velocities: [0.0, -0.6481, -0.5851, 0.0, 0.0, 0.0, -0.6842, 0.0]
+      positions: [0.0, 0.2072, 0.2659, 0.0436, 0.0, 0.6511, 1.2008, 0.0436]
+      velocities: [0.0, -0.5418, -0.4891, 0.0, 0.0, -0.9825, -1.3331, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
-        secs: 1
-        nsecs: 700000000
-    - 
-      positions: [0.0, 0.2064, 0.2651, 0.0436, 0.0, 0.8722, 1.2008, 0.0436]
-      velocities: [0.0, -0.5905, -0.5331, 0.0, 0.0, -0.8754, -1.3331, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 887999999
+        secs: 2
+        nsecs:  59600000
     - 
       positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
       velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
-        secs: 2
-        nsecs: 750000000
+        secs: 3
+        nsecs:         0
 duration: 
-  secs: 2
-  nsecs: 750000000
+  secs: 3
+  nsecs:         0
 sounds: []

--- a/march_gait_files/test_versions-v/stairs_up/right_close/MV_stairsup_rightclose_v5.subgait
+++ b/march_gait_files/test_versions-v/stairs_up/right_close/MV_stairsup_rightclose_v5.subgait
@@ -1,0 +1,86 @@
+name: "right_close"
+version: "MV_stairsup_rightclose_v5"
+description: "Stairs up with higher steps."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 399999999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 700000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 887999999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 750000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 1.1694, 1.1345, 0.0436, 0.0, 0.2269, 0.2443, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.1745, 0.6981, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.5273, 0.5548, 0.0436, 0.0, 0.9054, 1.4835, 0.0436]
+      velocities: [0.0, -0.6853, -0.6187, 0.0, 0.0, 0.335, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 399999999
+    - 
+      positions: [0.0, 0.3249, 0.3721, 0.0436, 0.0, 0.9599, 1.3917, 0.0436]
+      velocities: [0.0, -0.6481, -0.5851, 0.0, 0.0, 0.0, -0.6842, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 700000000
+    - 
+      positions: [0.0, 0.2064, 0.2651, 0.0436, 0.0, 0.8722, 1.2008, 0.0436]
+      velocities: [0.0, -0.5905, -0.5331, 0.0, 0.0, -0.8754, -1.3331, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 887999999
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 750000000
+duration: 
+  secs: 2
+  nsecs: 750000000
+sounds: []

--- a/march_gait_files/test_versions-v/stairs_up/right_open/MV_stairsup_rightopen_v5.subgait
+++ b/march_gait_files/test_versions-v/stairs_up/right_open/MV_stairsup_rightopen_v5.subgait
@@ -1,0 +1,86 @@
+name: "right_open"
+version: "MV_stairsup_rightopen_v5"
+description: "Stairs up with higher step and somewhat slower."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 199999999
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 963700000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 490000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 3
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0275, 0.0655, 0.0436, 0.0, 0.8684, 1.7453, 0.0436]
+      velocities: [0.0, 0.0946, 0.084, 0.0, 0.0, 1.0299, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 199999999
+    - 
+      positions: [0.0, 0.0619, 0.1231, 0.0436, 0.0, 1.309, 1.5123, 0.0436]
+      velocities: [0.0, 0.1376, 0.0566, 0.0, 0.0, -0.1222, -0.4961, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 963700000
+    - 
+      positions: [0.0, 0.1412, 0.1396, 0.0436, 0.0, 1.2223, 1.2545, 0.0436]
+      velocities: [0.0, 0.1596, 0.0, 0.0, 0.0, -0.1707, -0.4143, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 490000000
+    - 
+      positions: [0.0, 0.2269, 0.2443, 0.0436, 0.0, 1.1694, 1.1345, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 3
+        nsecs:         0
+duration: 
+  secs: 3
+  nsecs:         0
+sounds: []

--- a/march_gait_files/test_versions-v/stairs_up/right_open/MV_stairsup_rightopen_v5.subgait
+++ b/march_gait_files/test_versions-v/stairs_up/right_open/MV_stairsup_rightopen_v5.subgait
@@ -17,7 +17,7 @@ setpoints:
   - 
     time_from_start: 
       secs: 1
-      nsecs: 963700000
+      nsecs: 527300000
     joint_names: [right_hip_fe]
   - 
     time_from_start: 
@@ -49,24 +49,24 @@ trajectory:
         secs: 0
         nsecs:         0
     - 
-      positions: [0.0, -0.0275, 0.0655, 0.0436, 0.0, 0.8684, 1.7453, 0.0436]
-      velocities: [0.0, 0.0946, 0.084, 0.0, 0.0, 1.0299, 0.0, 0.0]
+      positions: [0.0, -0.0275, 0.0655, 0.0436, 0.0, 1.1634, 1.7453, 0.0436]
+      velocities: [0.0, 0.0946, 0.084, 0.0, 0.0, 0.9029, 0.0, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
         secs: 1
         nsecs: 199999999
     - 
-      positions: [0.0, 0.0619, 0.1231, 0.0436, 0.0, 1.309, 1.5123, 0.0436]
-      velocities: [0.0, 0.1376, 0.0566, 0.0, 0.0, -0.1222, -0.4961, 0.0]
+      positions: [0.0, 0.0072, 0.093, 0.0436, 0.0, 1.309, 1.6927, 0.0436]
+      velocities: [0.0, 0.1149, 0.0798, 0.0, 0.0, -0.1222, -0.3013, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
         secs: 1
-        nsecs: 963700000
+        nsecs: 527300000
     - 
-      positions: [0.0, 0.1412, 0.1396, 0.0436, 0.0, 1.2223, 1.2545, 0.0436]
-      velocities: [0.0, 0.1596, 0.0, 0.0, 0.0, -0.1707, -0.4143, 0.0]
+      positions: [0.0, 0.1412, 0.1396, 0.0436, 0.0, 1.1941, 1.2545, 0.0436]
+      velocities: [0.0, 0.1596, 0.0, 0.0, 0.0, -0.0883, -0.4143, 0.0]
       accelerations: []
       effort: []
       time_from_start: 

--- a/march_gait_files/test_versions-v/stairs_up/right_swing/MV_stairsup_rightswing_v5.subgait
+++ b/march_gait_files/test_versions-v/stairs_up/right_swing/MV_stairsup_rightswing_v5.subgait
@@ -1,0 +1,86 @@
+name: "right_swing"
+version: "MV_stairsup_rightswing_v5"
+description: "Stairs up with higher steps."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 100000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 800000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 282500000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 750000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 1.1694, 1.1345, 0.0436, 0.0, 0.2269, 0.2443, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.1745, 0.6981, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.7949, 0.6679, 0.0436, 0.0, 1.0014, 1.7453, 0.0436]
+      velocities: [0.0, -0.5486, -0.6527, 0.0, 0.0, 0.8166, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 100000000
+    - 
+      positions: [0.0, 0.4172, 0.2557, 0.0436, 0.0, 1.309, 1.5107, 0.0436]
+      velocities: [0.0, -0.4704, -0.4383, 0.0, 0.0, -0.1222, -0.5418, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 800000000
+    - 
+      positions: [0.0, 0.2441, 0.1396, 0.0436, 0.0, 1.2241, 1.2557, 0.0436]
+      velocities: [0.0, -0.2221, 0.0, 0.0, 0.0, -0.1894, -0.4534, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 282500000
+    - 
+      positions: [0.0, 0.2269, 0.2443, 0.0436, 0.0, 1.1694, 1.1345, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 750000000
+duration: 
+  secs: 2
+  nsecs: 750000000
+sounds: []

--- a/march_gait_files/test_versions-v/stairs_up/right_swing/MV_stairsup_rightswing_v5.subgait
+++ b/march_gait_files/test_versions-v/stairs_up/right_swing/MV_stairsup_rightswing_v5.subgait
@@ -12,22 +12,22 @@ setpoints:
   - 
     time_from_start: 
       secs: 1
-      nsecs: 100000000
+      nsecs: 199999999
     joint_names: [right_knee]
   - 
     time_from_start: 
       secs: 1
-      nsecs: 800000000
+      nsecs: 527300000
     joint_names: [right_hip_fe]
   - 
     time_from_start: 
       secs: 2
-      nsecs: 282500000
+      nsecs: 490000000
     joint_names: [left_knee]
   - 
     time_from_start: 
-      secs: 2
-      nsecs: 750000000
+      secs: 3
+      nsecs:         0
     joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
   right_ankle]
 trajectory: 
@@ -49,38 +49,38 @@ trajectory:
         secs: 0
         nsecs:         0
     - 
-      positions: [0.0, 0.7949, 0.6679, 0.0436, 0.0, 1.0014, 1.7453, 0.0436]
-      velocities: [0.0, -0.5486, -0.6527, 0.0, 0.0, 0.8166, 0.0, 0.0]
+      positions: [0.0, 0.7904, 0.6676, 0.0436, 0.0, 1.2117, 1.7453, 0.0436]
+      velocities: [0.0, -0.5076, -0.5983, 0.0, 0.0, 0.6411, 0.0, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
         secs: 1
-        nsecs: 100000000
+        nsecs: 199999999
     - 
-      positions: [0.0, 0.4172, 0.2557, 0.0436, 0.0, 1.309, 1.5107, 0.0436]
-      velocities: [0.0, -0.4704, -0.4383, 0.0, 0.0, -0.1222, -0.5418, 0.0]
+      positions: [0.0, 0.6198, 0.472, 0.0436, 0.0, 1.309, 1.6927, 0.0436]
+      velocities: [0.0, -0.5132, -0.569, 0.0, 0.0, -0.1222, -0.3013, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
         secs: 1
-        nsecs: 800000000
+        nsecs: 527300000
     - 
-      positions: [0.0, 0.2441, 0.1396, 0.0436, 0.0, 1.2241, 1.2557, 0.0436]
-      velocities: [0.0, -0.2221, 0.0, 0.0, 0.0, -0.1894, -0.4534, 0.0]
+      positions: [0.0, 0.2384, 0.1396, 0.0436, 0.0, 1.1941, 1.2545, 0.0436]
+      velocities: [0.0, -0.196, 0.0, 0.0, 0.0, -0.0883, -0.4143, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
         secs: 2
-        nsecs: 282500000
+        nsecs: 490000000
     - 
       positions: [0.0, 0.2269, 0.2443, 0.0436, 0.0, 1.1694, 1.1345, 0.0436]
       velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
       accelerations: []
       effort: []
       time_from_start: 
-        secs: 2
-        nsecs: 750000000
+        secs: 3
+        nsecs:         0
 duration: 
-  secs: 2
-  nsecs: 750000000
+  secs: 3
+  nsecs:         0
 sounds: []


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
--> Made a new version of the stairs gait and adjusted the high step and straight starting step for the Tilted Path. This all in airgait-v.

The new stairs gait has more exaggerated movement; we hope the toe does not touch the step anymore in this way. The ankles are not used. Moreover, the duration is set higher, to 3 seconds instead of 2.7 seconds.
The high step and straight starting step have a little lower velocity in the right open (approximately 114 to 80), this should be better with effort mode. The gait has not really changed for the rest.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
--> * New version of the stairs gait (v5).
* New version of the right_open of the Rough Terrain high step (v7).
* New version of the right_open of the Tilted Path straight (v2).
* These gaits are set to default in airgait-v.

<!-- Please don't forget to request for reviews -->
