### PR TITLE
Created a new single step with flexed left knee at the end, so you ca…

### DIFF
--- a/march_gait_files/airgait-v/default.yaml
+++ b/march_gait_files/airgait-v/default.yaml
@@ -30,6 +30,8 @@ gaits:
   tilted_path_single_step: {right_open: MV_TP_singlestep_rightopen_v1, left_close: MV_TP_singlestep_leftclose_v1}
   tilted_path_straight_end: {left_open: MV_TP_straightend_leftopen_v1,
                              right_close: MV_TP_straightend_rightclose_v1}
+  tilted_path_flexed_knee_step: {right_open: MV_TP_flexed_knee_step_rightopen_v1,
+                                 left_close: MV_TP_flexed_knee_step_leftclose_v1}
   stairs_up: {right_open: MV_stairsup_rightopen_v5, left_swing: MV_stairsup_leftswing_v5,
               right_swing: MV_stairsup_rightswing_v5, left_close: MV_stairsup_leftclose_v5,
               right_close: MV_stairsup_rightclose_v5}

--- a/march_gait_files/airgait-v/tilted_path_flexed_knee_step/left_close/MV_TP_flexed_knee_step_leftclose_v1.subgait
+++ b/march_gait_files/airgait-v/tilted_path_flexed_knee_step/left_close/MV_TP_flexed_knee_step_leftclose_v1.subgait
@@ -1,0 +1,100 @@
+name: "left_close"
+version: "MV_TP_flexed_knee_step_leftclose_v1"
+description: "Left close in which the left knee bends at the end of the gait, so that the TP single\
+  \ step can be executed after this sugait."
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 496000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 581200000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 620000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 775000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 550000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1381, 0.1062, 0.0436]
+      velocities: [0.0, 1.1848, 0.0, 0.0, 0.0, -0.348, -0.1172, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 496000000
+    - 
+      positions: [0.0, 0.5414, 0.87, 0.0436, 0.0, 0.1104, 0.0964, 0.0436]
+      velocities: [0.0, 0.5852, -0.0679, 0.0, 0.0, -0.3381, -0.126, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 581200000
+    - 
+      positions: [0.0, 0.5585, 0.8666, 0.0436, 0.0, 0.097, 0.0912, 0.0436]
+      velocities: [0.0, 0.1396, -0.0988, 0.0, 0.0, -0.3321, -0.1293, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 620000000
+    - 
+      positions: [0.0, 0.5619, 0.8425, 0.0436, 0.0, 0.0458, 0.0698, 0.0436]
+      velocities: [0.0, -0.0826, -0.1935, 0.0, 0.0, -0.3013, -0.1351, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 775000000
+    - 
+      positions: [0.0, 0.4014, 0.6981, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 550000000
+duration: 
+  secs: 1
+  nsecs: 550000000
+sounds: []

--- a/march_gait_files/airgait-v/tilted_path_flexed_knee_step/right_open/MV_TP_flexed_knee_step_rightopen_v1.subgait
+++ b/march_gait_files/airgait-v/tilted_path_flexed_knee_step/right_open/MV_TP_flexed_knee_step_rightopen_v1.subgait
@@ -1,0 +1,125 @@
+name: "right_open"
+version: "MV_TP_flexed_knee_step_rightopen_v1"
+description: "Just the right open of the normal single step."
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 562400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 750000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 900000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3269, 0.8374, 0.0436, 0.0, -0.1118, 0.0787, 0.0436]
+      velocities: [0.0, 1.0059, 0.8848, 0.0, 0.0, -0.074, 0.2038, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 562400000
+    - 
+      positions: [0.0, 0.3952, 0.8727, 0.0436, 0.0, -0.1171, 0.0928, 0.0436]
+      velocities: [0.0, 0.9229, 0.0, 0.0, 0.0, -0.0772, 0.195, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [0.0, 0.4928, 0.8197, 0.0436, 0.0, -0.1266, 0.1146, 0.0436]
+      velocities: [0.0, 0.6697, -0.8675, 0.0, 0.0, -0.0794, 0.1617, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 750000000
+    - 
+      positions: [0.0, 0.5585, 0.6333, 0.0436, 0.0, -0.1384, 0.1339, 0.0436]
+      velocities: [0.0, 0.1396, -1.506, 0.0, 0.0, -0.0764, 0.0877, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 900000000
+    - 
+      positions: [0.0, 0.5513, 0.4416, 0.0436, 0.0, -0.1473, 0.1396, 0.0436]
+      velocities: [0.0, -0.2399, -1.6073, 0.0, 0.0, -0.0694, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [0.0, 0.3863, 0.0969, 0.0436, 0.0, -0.1644, 0.1396, 0.0436]
+      velocities: [0.0, -0.5678, 0.0, 0.0, 0.0, -0.0288, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/tilted_path_flexed_knee_step/tilted_path_flexed_knee_step.gait
+++ b/march_gait_files/airgait-v/tilted_path_flexed_knee_step/tilted_path_flexed_knee_step.gait
@@ -1,0 +1,5 @@
+name: tilted_path_flexed_knee_step
+
+graph:
+  from_subgait: [start,     right_open, left_close]
+  to_subgait:   [right_open, left_close, end]

--- a/march_gait_files/test_versions-v/default.yaml
+++ b/march_gait_files/test_versions-v/default.yaml
@@ -42,3 +42,5 @@ gaits:
   tilted_path_single_step: {right_open: MV_TP_singlestep_rightopen_v1, left_close: MV_TP_singlestep_leftclose_v1}
   tilted_path_straight_end: {left_open: MV_TP_straightend_leftopen_v1,
                              right_close: MV_TP_straightend_rightclose_v1}
+  tilted_path_flexed_knee_step: {right_open: MV_TP_flexed_knee_step_rightopen_v1,
+                                 left_close: MV_TP_flexed_knee_step_leftclose_v1}

--- a/march_gait_files/test_versions-v/tilted_path_flexed_knee_step/left_close/MV_TP_flexed_knee_step_leftclose_v1.subgait
+++ b/march_gait_files/test_versions-v/tilted_path_flexed_knee_step/left_close/MV_TP_flexed_knee_step_leftclose_v1.subgait
@@ -1,0 +1,100 @@
+name: "left_close"
+version: "MV_TP_flexed_knee_step_leftclose_v1"
+description: "Left close in which the left knee bends at the end of the gait, so that the TP single\
+  \ step can be executed after this sugait."
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 496000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 581200000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 620000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 775000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 550000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1381, 0.1062, 0.0436]
+      velocities: [0.0, 1.1848, 0.0, 0.0, 0.0, -0.348, -0.1172, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 496000000
+    - 
+      positions: [0.0, 0.5414, 0.87, 0.0436, 0.0, 0.1104, 0.0964, 0.0436]
+      velocities: [0.0, 0.5852, -0.0679, 0.0, 0.0, -0.3381, -0.126, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 581200000
+    - 
+      positions: [0.0, 0.5585, 0.8666, 0.0436, 0.0, 0.097, 0.0912, 0.0436]
+      velocities: [0.0, 0.1396, -0.0988, 0.0, 0.0, -0.3321, -0.1293, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 620000000
+    - 
+      positions: [0.0, 0.5619, 0.8425, 0.0436, 0.0, 0.0458, 0.0698, 0.0436]
+      velocities: [0.0, -0.0826, -0.1935, 0.0, 0.0, -0.3013, -0.1351, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 775000000
+    - 
+      positions: [0.0, 0.4014, 0.6981, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, 0.0, -0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 550000000
+duration: 
+  secs: 1
+  nsecs: 550000000
+sounds: []

--- a/march_gait_files/test_versions-v/tilted_path_flexed_knee_step/right_open/MV_TP_flexed_knee_step_rightopen_v1.subgait
+++ b/march_gait_files/test_versions-v/tilted_path_flexed_knee_step/right_open/MV_TP_flexed_knee_step_rightopen_v1.subgait
@@ -1,0 +1,125 @@
+name: "right_open"
+version: "MV_TP_flexed_knee_step_rightopen_v1"
+description: "Just the right open of the normal single step."
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 562400000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 750000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 900000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.3269, 0.8374, 0.0436, 0.0, -0.1118, 0.0787, 0.0436]
+      velocities: [0.0, 1.0059, 0.8848, 0.0, 0.0, -0.074, 0.2038, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 562400000
+    - 
+      positions: [0.0, 0.3952, 0.8727, 0.0436, 0.0, -0.1171, 0.0928, 0.0436]
+      velocities: [0.0, 0.9229, 0.0, 0.0, 0.0, -0.0772, 0.195, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [0.0, 0.4928, 0.8197, 0.0436, 0.0, -0.1266, 0.1146, 0.0436]
+      velocities: [0.0, 0.6697, -0.8675, 0.0, 0.0, -0.0794, 0.1617, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 750000000
+    - 
+      positions: [0.0, 0.5585, 0.6333, 0.0436, 0.0, -0.1384, 0.1339, 0.0436]
+      velocities: [0.0, 0.1396, -1.506, 0.0, 0.0, -0.0764, 0.0877, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 900000000
+    - 
+      positions: [0.0, 0.5513, 0.4416, 0.0436, 0.0, -0.1473, 0.1396, 0.0436]
+      velocities: [0.0, -0.2399, -1.6073, 0.0, 0.0, -0.0694, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [0.0, 0.3863, 0.0969, 0.0436, 0.0, -0.1644, 0.1396, 0.0436]
+      velocities: [0.0, -0.5678, 0.0, 0.0, 0.0, -0.0288, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
+      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/test_versions-v/tilted_path_flexed_knee_step/tilted_path_flexed_knee_step.gait
+++ b/march_gait_files/test_versions-v/tilted_path_flexed_knee_step/tilted_path_flexed_knee_step.gait
@@ -1,0 +1,5 @@
+name: tilted_path_flexed_knee_step
+
+graph:
+  from_subgait: [start,     right_open, left_close]
+  to_subgait:   [right_open, left_close, end]


### PR DESCRIPTION
…n go to the state TP STANDING STRAIGHT with a single step

<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->



## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
Since the only possible way to do the tilted path single steps on the grass part was by doing the tilted path straight start gait first, I made a special single step called the tilted_path_flexed_knee_step, in which the right open is just the same as in the single step normal, but in the left close the knee will bend at the end of the subgait so you will be in the STANDING TP STRAIGHT state after this single step. So when the straight start gait doesn't work well, we can now try the grass part of the tilted path by doing this single step first and then lift the exo on the grass (or do the single step on the grass as well). Since the simulation looked fine, I already put the gaits in de airgait-v folder.
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
--> 
- Added tilted_path_flexed_knee_step in test_versions-v
- Added tilted_path_flexed_knee_step in airgait-v
- Added these gaits to the default yaml

<!-- Please don't forget to request for reviews -->
