### PR TITLE
Fix/adjust stairs down gait

### DIFF
--- a/march_gait_files/airgait-v/stairs_down/left_close/MV_stairsdown_leftclose_v5.subgait
+++ b/march_gait_files/airgait-v/stairs_down/left_close/MV_stairsdown_leftclose_v5.subgait
@@ -1,0 +1,99 @@
+name: "left_close"
+version: "MV_stairsdown_leftclose_v5"
+description: "This version has some more flexion in the left hip"
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 500000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 429999999
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:         0
+    joint_names: [left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 4
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.6283, 1.4486, 0.0436, 0.0, 0.5061, 0.5236, 0.0436]
+      velocities: [0.0, 0.2618, 0.4363, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.7854, 1.4332, 0.0436, 0.0, 0.4632, 0.4797, 0.0436]
+      velocities: [0.0, 0.0, -0.4178, 0.0, 0.0, -0.1486, -0.1537, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4929, 0.7754, 0.0436, 0.0, 0.3491, 0.3504, 0.0436]
+      velocities: [0.0, -0.4129, -0.7013, 0.0, 0.0, 0.0, -0.0338, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 429999999
+    - 
+      positions: [0.0, 0.4647, 0.7279, 0.0436, 0.0, 0.3483, 0.3491, 0.0436]
+      velocities: [0.0, -0.3902, -0.6517, 0.0, 0.0, -0.0246, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.3491, 0.5411, 0.0436, 0.0, 0.2951, 0.3135, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.1747, -0.133, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 4
+        nsecs:         0
+duration: 
+  secs: 4
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/stairs_down/left_swing/MV_stairsdown_leftswing_v5.subgait
+++ b/march_gait_files/airgait-v/stairs_down/left_swing/MV_stairsdown_leftswing_v5.subgait
@@ -1,0 +1,99 @@
+name: "left_swing"
+version: "MV_stairsdown_leftswing_v5"
+description: "This version has 5 degrees more flexion in the left knee at the end."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 710000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 429999999
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee]
+  - 
+    time_from_start: 
+      secs: 4
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.6283, 1.4486, 0.0436, 0.0, 0.5061, 0.5236, 0.0436]
+      velocities: [0.0, 0.2618, 0.4363, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.7608, 1.6581, 0.0436, 0.0, 0.4617, 0.562, 0.0436]
+      velocities: [0.0, 0.1201, -0.2618, 0.0, 0.0, -0.1073, 0.0661, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 710000000
+    - 
+      positions: [0.0, 0.8029, 1.4066, 0.0436, 0.0, 0.3807, 0.553, 0.0436]
+      velocities: [0.0, 0.0, -0.423, 0.0, 0.0, -0.0966, -0.1369, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 429999999
+    - 
+      positions: [0.0, 0.8024, 1.3766, 0.0436, 0.0, 0.3742, 0.5411, 0.0436]
+      velocities: [0.0, -0.0168, -0.4324, 0.0, 0.0, -0.089, -0.1745, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.7662, 1.1492, 0.0436, 0.0, 0.3491, 0.5236, 0.0436]
+      velocities: [0.0, -0.1188, -0.4651, 0.0, 0.0, 0.0, 0.0873, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:         0
+    - 
+      positions: [0.0, 0.5061, 0.5236, 0.0436, 0.0, 0.6283, 1.4486, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.2618, 0.4363, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 4
+        nsecs:         0
+duration: 
+  secs: 4
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/stairs_down/right_close/MV_stairsdown_rightclose_v5.subgait
+++ b/march_gait_files/airgait-v/stairs_down/right_close/MV_stairsdown_rightclose_v5.subgait
@@ -1,0 +1,99 @@
+name: "right_close"
+version: "MV_stairsdown_rightclose_v5"
+description: "This version has some more flexion in the right hip"
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 500000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 429999999
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:         0
+    joint_names: [right_hip_fe, right_knee]
+  - 
+    time_from_start: 
+      secs: 4
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.5061, 0.5236, 0.0436, 0.0, 0.6283, 1.4486, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.2618, 0.4363, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4632, 0.4797, 0.0436, 0.0, 0.7854, 1.4332, 0.0436]
+      velocities: [0.0, -0.1486, -0.1537, 0.0, 0.0, 0.0, -0.4178, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.3491, 0.3504, 0.0436, 0.0, 0.4929, 0.7754, 0.0436]
+      velocities: [0.0, 0.0, -0.0338, 0.0, 0.0, -0.4129, -0.7013, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 429999999
+    - 
+      positions: [0.0, 0.3483, 0.3491, 0.0436, 0.0, 0.4647, 0.7279, 0.0436]
+      velocities: [0.0, -0.0246, 0.0, 0.0, 0.0, -0.3902, -0.6517, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.2951, 0.3135, 0.0436, 0.0, 0.3491, 0.5411, 0.0436]
+      velocities: [0.0, -0.1747, -0.133, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 4
+        nsecs:         0
+duration: 
+  secs: 4
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/stairs_down/right_open/MV_stairsdown_rightopen_v5.subgait
+++ b/march_gait_files/airgait-v/stairs_down/right_open/MV_stairsdown_rightopen_v5.subgait
@@ -1,0 +1,86 @@
+name: "right_open"
+version: "MV_stairsdown_rightopen_v5"
+description: "This version has 5 degrees more flexion in the right knee at the end."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 429999999
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_knee, right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:         0
+    joint_names: [left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 4
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.2612, 0.549, 0.0436, 0.0, 0.8029, 1.6636, 0.0436]
+      velocities: [0.0, 0.2686, -0.0356, 0.0, 0.0, 0.0, 0.1103, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 429999999
+    - 
+      positions: [0.0, 0.2794, 0.5411, 0.0436, 0.0, 0.8024, 1.6581, 0.0436]
+      velocities: [0.0, 0.2475, -0.1745, 0.0, 0.0, -0.0168, -0.2618, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.3491, 0.5236, 0.0436, 0.0, 0.7662, 1.4589, 0.0436]
+      velocities: [0.0, 0.0, 0.0873, 0.0, 0.0, -0.1188, -0.5176, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:         0
+    - 
+      positions: [0.0, 0.6283, 1.4486, 0.0436, 0.0, 0.5061, 0.5236, 0.0436]
+      velocities: [0.0, 0.2618, 0.4363, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 4
+        nsecs:         0
+duration: 
+  secs: 4
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/stairs_down/right_swing/MV_stairsdown_rightswing_v5.subgait
+++ b/march_gait_files/airgait-v/stairs_down/right_swing/MV_stairsdown_rightswing_v5.subgait
@@ -1,0 +1,99 @@
+name: "right_swing"
+version: "MV_stairsdown_rightswing_v5"
+description: "This version has 5 degrees more flexion in the right knee at the end."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 710000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 429999999
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:         0
+    joint_names: [left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 4
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.5061, 0.5236, 0.0436, 0.0, 0.6283, 1.4486, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.2618, 0.4363, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4617, 0.562, 0.0436, 0.0, 0.7608, 1.6581, 0.0436]
+      velocities: [0.0, -0.1073, 0.0661, 0.0, 0.0, 0.1201, -0.2618, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 710000000
+    - 
+      positions: [0.0, 0.3807, 0.553, 0.0436, 0.0, 0.8029, 1.4066, 0.0436]
+      velocities: [0.0, -0.0966, -0.1369, 0.0, 0.0, 0.0, -0.423, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 429999999
+    - 
+      positions: [0.0, 0.3742, 0.5411, 0.0436, 0.0, 0.8024, 1.3766, 0.0436]
+      velocities: [0.0, -0.089, -0.1745, 0.0, 0.0, -0.0168, -0.4324, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.3491, 0.5236, 0.0436, 0.0, 0.7662, 1.1492, 0.0436]
+      velocities: [0.0, 0.0, 0.0873, 0.0, 0.0, -0.1188, -0.4651, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:         0
+    - 
+      positions: [0.0, 0.6283, 1.4486, 0.0436, 0.0, 0.5061, 0.5236, 0.0436]
+      velocities: [0.0, 0.2618, 0.4363, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 4
+        nsecs:         0
+duration: 
+  secs: 4
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/stairs_down_single_step/left_close/MV_stairsdown_single_leftclose_v3.subgait
+++ b/march_gait_files/airgait-v/stairs_down_single_step/left_close/MV_stairsdown_single_leftclose_v3.subgait
@@ -1,0 +1,99 @@
+name: "left_close"
+version: "MV_stairsdown_single_leftclose_v3"
+description: "Just v5 of the left close of the stairs down gait."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 500000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 429999999
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:         0
+    joint_names: [left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 4
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.6283, 1.4486, 0.0436, 0.0, 0.5061, 0.5236, 0.0436]
+      velocities: [0.0, 0.2618, 0.4363, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.7854, 1.4332, 0.0436, 0.0, 0.4632, 0.4797, 0.0436]
+      velocities: [0.0, 0.0, -0.4178, 0.0, 0.0, -0.1486, -0.1537, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.4929, 0.7754, 0.0436, 0.0, 0.3491, 0.3504, 0.0436]
+      velocities: [0.0, -0.4129, -0.7013, 0.0, 0.0, 0.0, -0.0338, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 429999999
+    - 
+      positions: [0.0, 0.4647, 0.7279, 0.0436, 0.0, 0.3483, 0.3491, 0.0436]
+      velocities: [0.0, -0.3902, -0.6517, 0.0, 0.0, -0.0246, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.3491, 0.5411, 0.0436, 0.0, 0.2951, 0.3135, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.1747, -0.133, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 4
+        nsecs:         0
+duration: 
+  secs: 4
+  nsecs:         0
+sounds: []

--- a/march_gait_files/airgait-v/stairs_down_single_step/right_open/MV_stairsdown_single_rightopen_v3.subgait
+++ b/march_gait_files/airgait-v/stairs_down_single_step/right_open/MV_stairsdown_single_rightopen_v3.subgait
@@ -1,0 +1,86 @@
+name: "right_open"
+version: "MV_stairsdown_single_rightopen_v3"
+description: "Just v5 of the right open of the stairs down gait."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 429999999
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_knee, right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:         0
+    joint_names: [left_hip_fe, left_knee]
+  - 
+    time_from_start: 
+      secs: 4
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.2612, 0.549, 0.0436, 0.0, 0.8029, 1.6636, 0.0436]
+      velocities: [0.0, 0.2686, -0.0356, 0.0, 0.0, 0.0, 0.1103, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 429999999
+    - 
+      positions: [0.0, 0.2794, 0.5411, 0.0436, 0.0, 0.8024, 1.6581, 0.0436]
+      velocities: [0.0, 0.2475, -0.1745, 0.0, 0.0, -0.0168, -0.2618, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, 0.3491, 0.5236, 0.0436, 0.0, 0.7662, 1.4589, 0.0436]
+      velocities: [0.0, 0.0, 0.0873, 0.0, 0.0, -0.1188, -0.5176, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:         0
+    - 
+      positions: [0.0, 0.6283, 1.4486, 0.0436, 0.0, 0.5061, 0.5236, 0.0436]
+      velocities: [0.0, 0.2618, 0.4363, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 4
+        nsecs:         0
+duration: 
+  secs: 4
+  nsecs:         0
+sounds: []


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->



## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
Made a new version of the stairs down gait. In this version, the knee flexion ends at 30 degrees (instead of 25 before) in the right open en the swing subgaits. Furthermore, there is some hip flexion added in the closing subgaits to prevent the shoes from scratching the stairs.
I also added a new stairs down single step with the new right open and left close subgaits.
All these new gait files are added to the airgait-v folder.
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
Added the following gait files:

Stairs down
- MV_stairsdown_rightopen_v5
- MV_stairsdown_leftswing_v5
- MV_stairsdown_rightswing_v5
- MV_stairsdown_leftclose_v5
- MV_stairsdown_rightclose_v5

Stairs down single step
- MV_stairsdown_single_rightopen_v3
- MV_stairsdown_single_leftclose_v3

<!-- Please don't forget to request for reviews -->
