### PR TITLE
Feature/new stairs gait versions

### DIFF
--- a/march_gait_files/airgait-v/default.yaml
+++ b/march_gait_files/airgait-v/default.yaml
@@ -42,7 +42,7 @@ gaits:
   stairs_up: {right_open: MV_stairsup_rightopen_v13, left_swing: MV_stairsup_leftswing_v13,
               right_swing: MV_stairsup_rightswing_v13, left_close: MV_stairsup_leftclose_v13,
               right_close: MV_stairsup_rightclose_v13}
-  stairs_up_single_step: {right_open: MV_stairsup_single_rightopen_v2, left_close: MV_stairsup_single_leftclose_v2}
+  stairs_up_single_step: {right_open: MV_stairsup_single_rightopen_v4, left_close: MV_stairsup_single_leftclose_v4}
   stairs_down_single_step: {right_open: MV_stairsdown_single_rightopen_v2,
                             left_close: MV_stairsdown_single_leftclose_v2}
   stairs_down: {right_open: MIV_final, left_swing: MIV_final,

--- a/march_gait_files/airgait-v/default.yaml
+++ b/march_gait_files/airgait-v/default.yaml
@@ -39,9 +39,9 @@ gaits:
   tilted_path_right_straight_end: {right_open: MV_TP_right_straightend_rightopen_v5,
                                    left_close: MV_TP_right_straightend_leftclose_v5}
   tilted_path_right_knee_bend: {right_open: MV_TP_right_kneebend_rightopen_v5}
-  stairs_up: {right_open: MV_stairsup_rightopen_v8, left_swing: MV_stairsup_leftswing_v8,
-              right_swing: MV_stairsup_rightswing_v8, left_close: MV_stairsup_leftclose_v12,
-              right_close: MV_stairsup_rightclose_v12}
+  stairs_up: {right_open: MV_stairsup_rightopen_v13, left_swing: MV_stairsup_leftswing_v13,
+              right_swing: MV_stairsup_rightswing_v13, left_close: MV_stairsup_leftclose_v13,
+              right_close: MV_stairsup_rightclose_v13}
   stairs_up_single_step: {right_open: MV_stairsup_single_rightopen_v2, left_close: MV_stairsup_single_leftclose_v2}
   stairs_down_single_step: {right_open: MV_stairsdown_single_rightopen_v2,
                             left_close: MV_stairsdown_single_leftclose_v2}

--- a/march_gait_files/airgait-v/default.yaml
+++ b/march_gait_files/airgait-v/default.yaml
@@ -16,8 +16,8 @@ gaits:
                                      left_close: MV_RT_second_middlestep_leftclose_v1}
   rough_terrain_third_middle_step: {right_open: MV_RT_third_middlestep_rightopen_v2,
                                     left_close: MV_RT_third_middlestep_leftclose_v2}
-  walk: {right_open: MV_walk_rightopen_v2, left_swing: MV_walk_leftswing_v2, right_swing: MV_walk_rightswing_v2,
-         left_close: MV_walk_leftclose_v2, right_close: MV_walk_rightclose_v2}
+  walk: {right_open: MV_walk_rightopen_v3, left_swing: MV_walk_leftswing_v2, right_swing: MV_walk_rightswing_v2,
+         left_close: MV_walk_leftclose_v3, right_close: MV_walk_rightclose_v3}
   single_step_normal: {right_open: MIV_final, left_close: MIV_final}
   sit: {sit_down: MIV_final, sit_home: MIV_final}
   stand: {prepare_stand_up: MIV_final, stand_up: MIV_final}

--- a/march_gait_files/airgait-v/stairs_up/left_close/MV_stairsup_leftclose_v13.subgait
+++ b/march_gait_files/airgait-v/stairs_up/left_close/MV_stairsup_leftclose_v13.subgait
@@ -1,0 +1,86 @@
+name: "left_close"
+version: "MV_stairsup_leftclose_v13"
+description: "A faster version of v12."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 272799999
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.0349, 0.2443, 0.0436, 0.0, 1.1694, 1.0647, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.8545, 1.4835, 0.0436, 0.0, 0.7314, 0.6936, 0.0436]
+      velocities: [0.0, 0.6946, 0.0, 0.0, 0.0, -0.7224, -0.612, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, 0.9599, 1.4174, 0.0436, 0.0, 0.5297, 0.5227, 0.0436]
+      velocities: [0.0, 0.0, -0.5555, 0.0, 0.0, -0.7539, -0.6387, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 272799999
+    - 
+      positions: [0.0, 0.8686, 1.2008, 0.0436, 0.0, 0.358, 0.3772, 0.0436]
+      velocities: [0.0, -0.7618, -1.3331, 0.0, 0.0, -0.7248, -0.6141, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up/left_close/MV_stairsup_leftclose_v14.subgait
+++ b/march_gait_files/airgait-v/stairs_up/left_close/MV_stairsup_leftclose_v14.subgait
@@ -1,0 +1,86 @@
+name: "left_close"
+version: "MV_stairsup_leftclose_v14"
+description: "A faster version of v12 and adjusted stance leg."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 272799999
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.0873, 0.2443, 0.0436, 0.0, 1.1694, 1.0647, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.8609, 1.4835, 0.0436, 0.0, 0.7314, 0.6936, 0.0436]
+      velocities: [0.0, 0.6524, 0.0, 0.0, 0.0, -0.7224, -0.612, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, 0.9599, 1.4174, 0.0436, 0.0, 0.5297, 0.5227, 0.0436]
+      velocities: [0.0, 0.0, -0.5555, 0.0, 0.0, -0.7539, -0.6387, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 272799999
+    - 
+      positions: [0.0, 0.8686, 1.2008, 0.0436, 0.0, 0.358, 0.3772, 0.0436]
+      velocities: [0.0, -0.7618, -1.3331, 0.0, 0.0, -0.7248, -0.6141, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up/left_swing/MV_stairsup_leftswing_v13.subgait
+++ b/march_gait_files/airgait-v/stairs_up/left_swing/MV_stairsup_leftswing_v13.subgait
@@ -1,0 +1,86 @@
+name: "left_swing"
+version: "MV_stairsup_leftswing_v13"
+description: "A faster version of v8."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 916700000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 166700000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  75000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.0349, 0.2443, 0.0436, 0.0, 1.1694, 1.0647, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 1.2277, 1.7453, 0.0436, 0.0, 0.7886, 0.6846, 0.0436]
+      velocities: [0.0, 1.0742, -0.5236, 0.0, 0.0, -0.689, -0.6592, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 916700000
+    - 
+      positions: [0.0, 1.3614, 1.6081, 0.0436, 0.0, 0.6096, 0.5175, 0.0436]
+      velocities: [0.0, -0.1222, -0.5748, 0.0, 0.0, -0.7265, -0.6587, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 166700000
+    - 
+      positions: [0.0, 1.2052, 1.1441, 0.0436, 0.0, 0.0732, 0.1396, 0.0436]
+      velocities: [0.0, -0.1485, -0.3428, 0.0, 0.0, -0.3194, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  75000000
+    - 
+      positions: [0.0, 1.1694, 1.0647, 0.0436, 0.0, 0.0349, 0.2443, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.1745, 0.6981, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up/left_swing/MV_stairsup_leftswing_v14.subgait
+++ b/march_gait_files/airgait-v/stairs_up/left_swing/MV_stairsup_leftswing_v14.subgait
@@ -1,0 +1,86 @@
+name: "left_swing"
+version: "MV_stairsup_leftswing_v14"
+description: "A faster version of v9."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 916700000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 166700000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  75000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.0873, 0.2443, 0.0436, 0.0, 1.1694, 1.0647, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 1.2341, 1.7453, 0.0436, 0.0, 0.8045, 0.6846, 0.0436]
+      velocities: [0.0, 1.0284, -0.5236, 0.0, 0.0, -0.6599, -0.6592, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 916700000
+    - 
+      positions: [0.0, 1.3614, 1.6081, 0.0436, 0.0, 0.6331, 0.5175, 0.0436]
+      velocities: [0.0, -0.1222, -0.5748, 0.0, 0.0, -0.6952, -0.6587, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 166700000
+    - 
+      positions: [0.0, 1.2052, 1.1441, 0.0436, 0.0, 0.1214, 0.1396, 0.0436]
+      velocities: [0.0, -0.1485, -0.3428, 0.0, 0.0, -0.3015, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  75000000
+    - 
+      positions: [0.0, 1.1694, 1.0647, 0.0436, 0.0, 0.0873, 0.2443, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.1745, 0.6981, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up/right_close/MV_stairsup_rightclose_v13.subgait
+++ b/march_gait_files/airgait-v/stairs_up/right_close/MV_stairsup_rightclose_v13.subgait
@@ -1,0 +1,86 @@
+name: "right_close"
+version: "MV_stairsup_rightclose_v13"
+description: "A faster version of v12."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 272799999
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 1.1694, 1.0647, 0.0436, 0.0, 0.0349, 0.2443, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.1745, 0.6981, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.7314, 0.6936, 0.0436, 0.0, 0.8545, 1.4835, 0.0436]
+      velocities: [0.0, -0.7224, -0.612, 0.0, 0.0, 0.6946, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, 0.5297, 0.5227, 0.0436, 0.0, 0.9599, 1.4288, 0.0436]
+      velocities: [0.0, -0.7539, -0.6387, 0.0, 0.0, 0.0, -0.4931, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 272799999
+    - 
+      positions: [0.0, 0.358, 0.3772, 0.0436, 0.0, 0.8686, 1.2217, 0.0436]
+      velocities: [0.0, -0.7248, -0.6141, 0.0, 0.0, -0.7618, -1.3331, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up/right_close/MV_stairsup_rightclose_v14.subgait
+++ b/march_gait_files/airgait-v/stairs_up/right_close/MV_stairsup_rightclose_v14.subgait
@@ -1,0 +1,86 @@
+name: "right_close"
+version: "MV_stairsup_rightclose_v14"
+description: "A faster version of v12 and adjusted stance leg."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 272799999
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 1.1694, 1.0647, 0.0436, 0.0, 0.0873, 0.2443, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.1745, 0.6981, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.7314, 0.6936, 0.0436, 0.0, 0.8609, 1.4835, 0.0436]
+      velocities: [0.0, -0.7224, -0.612, 0.0, 0.0, 0.6524, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, 0.5297, 0.5227, 0.0436, 0.0, 0.9599, 1.4288, 0.0436]
+      velocities: [0.0, -0.7539, -0.6387, 0.0, 0.0, 0.0, -0.4931, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 272799999
+    - 
+      positions: [0.0, 0.358, 0.3772, 0.0436, 0.0, 0.8686, 1.2217, 0.0436]
+      velocities: [0.0, -0.7248, -0.6141, 0.0, 0.0, -0.7618, -1.3331, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up/right_open/MV_stairsup_rightopen_v13.subgait
+++ b/march_gait_files/airgait-v/stairs_up/right_open/MV_stairsup_rightopen_v13.subgait
@@ -1,0 +1,86 @@
+name: "right_open"
+version: "MV_stairsup_rightopen_v13"
+description: "A faster version of v8."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 272799999
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  75000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0863, 0.0654, 0.0436, 0.0, 1.1581, 1.7453, 0.0436]
+      velocities: [0.0, 0.0142, 0.1007, 0.0, 0.0, 1.0933, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0803, 0.0924, 0.0436, 0.0, 1.309, 1.6891, 0.0436]
+      velocities: [0.0, 0.0308, 0.0961, 0.0, 0.0, -0.1222, -0.3961, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 272799999
+    - 
+      positions: [0.0, -0.0263, 0.1396, 0.0436, 0.0, 1.197, 1.2014, 0.0436]
+      velocities: [0.0, 0.1115, 0.0, 0.0, 0.0, -0.115, -0.558, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  75000000
+    - 
+      positions: [0.0, 0.0349, 0.2443, 0.0436, 0.0, 1.1694, 1.0647, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up/right_open/MV_stairsup_rightopen_v14.subgait
+++ b/march_gait_files/airgait-v/stairs_up/right_open/MV_stairsup_rightopen_v14.subgait
@@ -1,0 +1,86 @@
+name: "right_open"
+version: "MV_stairsup_rightopen_v14"
+description: "A faster version of v9."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 272799999
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  75000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.068, 0.0654, 0.0436, 0.0, 1.1581, 1.7453, 0.0436]
+      velocities: [0.0, 0.0444, 0.1007, 0.0, 0.0, 1.0933, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0536, 0.0924, 0.0436, 0.0, 1.309, 1.6891, 0.0436]
+      velocities: [0.0, 0.0622, 0.0961, 0.0, 0.0, -0.1222, -0.3961, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 272799999
+    - 
+      positions: [0.0, 0.0219, 0.1396, 0.0436, 0.0, 1.197, 1.2014, 0.0436]
+      velocities: [0.0, 0.1294, 0.0, 0.0, 0.0, -0.115, -0.558, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  75000000
+    - 
+      positions: [0.0, 0.0873, 0.2443, 0.0436, 0.0, 1.1694, 1.0647, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up/right_swing/MV_stairsup_rightswing_v13.subgait
+++ b/march_gait_files/airgait-v/stairs_up/right_swing/MV_stairsup_rightswing_v13.subgait
@@ -1,0 +1,86 @@
+name: "right_swing"
+version: "MV_stairsup_rightswing_v13"
+description: "A faster version of v8."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 916700000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 166700000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  75000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 1.1694, 1.0647, 0.0436, 0.0, 0.0349, 0.2443, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.1745, 0.6981, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.7886, 0.6846, 0.0436, 0.0, 1.2277, 1.7453, 0.0436]
+      velocities: [0.0, -0.689, -0.6592, 0.0, 0.0, 1.0742, -0.5236, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 916700000
+    - 
+      positions: [0.0, 0.6096, 0.5175, 0.0436, 0.0, 1.3614, 1.6081, 0.0436]
+      velocities: [0.0, -0.7265, -0.6587, 0.0, 0.0, -0.1222, -0.5748, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 166700000
+    - 
+      positions: [0.0, 0.0732, 0.1396, 0.0436, 0.0, 1.2052, 1.1441, 0.0436]
+      velocities: [0.0, -0.3194, 0.0, 0.0, 0.0, -0.1485, -0.3428, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  75000000
+    - 
+      positions: [0.0, 0.0349, 0.2443, 0.0436, 0.0, 1.1694, 1.0647, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up/right_swing/MV_stairsup_rightswing_v14.subgait
+++ b/march_gait_files/airgait-v/stairs_up/right_swing/MV_stairsup_rightswing_v14.subgait
@@ -1,0 +1,86 @@
+name: "right_swing"
+version: "MV_stairsup_rightswing_v14"
+description: "A faster version of v9."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 916700000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 166700000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  75000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 1.1694, 1.0647, 0.0436, 0.0, 0.0873, 0.2443, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.1745, 0.6981, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.8045, 0.6846, 0.0436, 0.0, 1.2341, 1.7453, 0.0436]
+      velocities: [0.0, -0.6599, -0.6592, 0.0, 0.0, 1.0284, -0.5236, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 916700000
+    - 
+      positions: [0.0, 0.6331, 0.5175, 0.0436, 0.0, 1.3614, 1.6081, 0.0436]
+      velocities: [0.0, -0.6952, -0.6587, 0.0, 0.0, -0.1222, -0.5748, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 166700000
+    - 
+      positions: [0.0, 0.1214, 0.1396, 0.0436, 0.0, 1.2052, 1.1441, 0.0436]
+      velocities: [0.0, -0.3015, 0.0, 0.0, 0.0, -0.1485, -0.3428, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  75000000
+    - 
+      positions: [0.0, 0.0873, 0.2443, 0.0436, 0.0, 1.1694, 1.0647, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up_single_step/left_close/MV_stairsup_single_leftclose_v4.subgait
+++ b/march_gait_files/airgait-v/stairs_up_single_step/left_close/MV_stairsup_single_leftclose_v4.subgait
@@ -1,0 +1,86 @@
+name: "left_close"
+version: "MV_stairsup_single_leftclose_v4"
+description: "Single step for the stairs corresponding to version 13 of stairs up."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 272799999
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.0349, 0.2443, 0.0436, 0.0, 1.1694, 1.0647, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.8545, 1.4835, 0.0436, 0.0, 0.7314, 0.6936, 0.0436]
+      velocities: [0.0, 0.6946, 0.0, 0.0, 0.0, -0.7224, -0.612, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, 0.9599, 1.4174, 0.0436, 0.0, 0.5297, 0.5227, 0.0436]
+      velocities: [0.0, 0.0, -0.5555, 0.0, 0.0, -0.7539, -0.6387, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 272799999
+    - 
+      positions: [0.0, 0.8686, 1.2008, 0.0436, 0.0, 0.358, 0.3772, 0.0436]
+      velocities: [0.0, -0.7618, -1.3331, 0.0, 0.0, -0.7248, -0.6141, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up_single_step/left_close/MV_stairsup_single_leftclose_v5.subgait
+++ b/march_gait_files/airgait-v/stairs_up_single_step/left_close/MV_stairsup_single_leftclose_v5.subgait
@@ -1,0 +1,86 @@
+name: "left_close"
+version: "MV_stairsup_single_leftclose_v5"
+description: "Single step for stairs up corresponding to version 14 of stairs up."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 272799999
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.0873, 0.2443, 0.0436, 0.0, 1.1694, 1.0647, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.8609, 1.4835, 0.0436, 0.0, 0.7314, 0.6936, 0.0436]
+      velocities: [0.0, 0.6524, 0.0, 0.0, 0.0, -0.7224, -0.612, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, 0.9599, 1.4174, 0.0436, 0.0, 0.5297, 0.5227, 0.0436]
+      velocities: [0.0, 0.0, -0.5555, 0.0, 0.0, -0.7539, -0.6387, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 272799999
+    - 
+      positions: [0.0, 0.8686, 1.2008, 0.0436, 0.0, 0.358, 0.3772, 0.0436]
+      velocities: [0.0, -0.7618, -1.3331, 0.0, 0.0, -0.7248, -0.6141, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up_single_step/right_open/MV_stairsup_single_rightopen_v4.subgait
+++ b/march_gait_files/airgait-v/stairs_up_single_step/right_open/MV_stairsup_single_rightopen_v4.subgait
@@ -1,0 +1,86 @@
+name: "right_open"
+version: "MV_stairsup_single_rightopen_v4"
+description: "Single step for the stairs corresponding to stairs up version 13."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 272799999
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  75000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0863, 0.0654, 0.0436, 0.0, 1.1581, 1.7453, 0.0436]
+      velocities: [0.0, 0.0142, 0.1007, 0.0, 0.0, 1.0933, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0803, 0.0924, 0.0436, 0.0, 1.309, 1.6891, 0.0436]
+      velocities: [0.0, 0.0308, 0.0961, 0.0, 0.0, -0.1222, -0.3961, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 272799999
+    - 
+      positions: [0.0, -0.0263, 0.1396, 0.0436, 0.0, 1.197, 1.2014, 0.0436]
+      velocities: [0.0, 0.1115, 0.0, 0.0, 0.0, -0.115, -0.558, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  75000000
+    - 
+      positions: [0.0, 0.0349, 0.2443, 0.0436, 0.0, 1.1694, 1.0647, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/stairs_up_single_step/right_open/MV_stairsup_single_rightopen_v5.subgait
+++ b/march_gait_files/airgait-v/stairs_up_single_step/right_open/MV_stairsup_single_rightopen_v5.subgait
@@ -1,0 +1,86 @@
+name: "right_open"
+version: "MV_stairsup_single_rightopen_v5"
+description: "Single step for the stairs corresponding to version 14 of stairs up."
+gait_type: "stairs_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 272799999
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs:  75000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 500000000
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, -0.068, 0.0654, 0.0436, 0.0, 1.1581, 1.7453, 0.0436]
+      velocities: [0.0, 0.0444, 0.1007, 0.0, 0.0, 1.0933, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, -0.0536, 0.0924, 0.0436, 0.0, 1.309, 1.6891, 0.0436]
+      velocities: [0.0, 0.0622, 0.0961, 0.0, 0.0, -0.1222, -0.3961, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 272799999
+    - 
+      positions: [0.0, 0.0219, 0.1396, 0.0436, 0.0, 1.197, 1.2014, 0.0436]
+      velocities: [0.0, 0.1294, 0.0, 0.0, 0.0, -0.115, -0.558, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs:  75000000
+    - 
+      positions: [0.0, 0.0873, 0.2443, 0.0436, 0.0, 1.1694, 1.0647, 0.0436]
+      velocities: [0.0, 0.1745, 0.6981, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 500000000
+duration: 
+  secs: 2
+  nsecs: 500000000
+sounds: []


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
--> I added two new versions of the stairs_up gait.
- Version 13 is the right_open, left_swing and right_swing version 8, and the left_close and right_close version 12 - but all subgaits are 2.5 seconds instead of 3 seconds. So in this gait, the stance leg goes to 2 degrees flexion.
- Version 14 is the right_open, left_swing and right_swing version 9, and the left_close and right_close version 12 but then adjusted to version 9 - but all subgaits are 2.5 seconds instead of 3 seconds. So in this gait, the stance leg goes to 5 degrees flexion.

I also added two new versions of the stairs_up_single_step, of which version 4 corresponds to stairs_up version 13, and version 5 corresponds to stairs_up version 14.

These gaits only exist in airgait-v for now, and stairs_up version 13 and stairs_up_single_step version 4 are default. I also changed the default of the walk in this gait directory to version 2 for the swing subgaits (as it was) and version 3 for the open and close subgaits.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
--> 
In airgait-v:
- Two new versions of the stairs up gait (v13 and v14; v13 default).
- Two new versions of the stairs up single step gait (v4 and v5; v4 default).
- Walk right_open, left_close and right_close v3 default.

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
