### PR TITLE
Make walk closing steps v3a and set default in airgait-v

### DIFF
--- a/march_gait_files/airgait-v/default.yaml
+++ b/march_gait_files/airgait-v/default.yaml
@@ -17,7 +17,7 @@ gaits:
   rough_terrain_third_middle_step: {right_open: MV_RT_third_middlestep_rightopen_v2,
                                     left_close: MV_RT_third_middlestep_leftclose_v2}
   walk: {right_open: MV_walk_rightopen_v3, left_swing: MV_walk_leftswing_v2, right_swing: MV_walk_rightswing_v2,
-         left_close: MV_walk_leftclose_v3, right_close: MV_walk_rightclose_v3}
+         left_close: MV_walk_leftclose_v3a, right_close: MV_walk_rightclose_v3a}
   single_step_normal: {right_open: MIV_final, left_close: MIV_final}
   sit: {sit_down: MIV_final, sit_home: MIV_final}
   stand: {prepare_stand_up: MIV_final, stand_up: MIV_final}

--- a/march_gait_files/airgait-v/walk/left_close/MV_walk_leftclose_v3a.subgait
+++ b/march_gait_files/airgait-v/walk/left_close/MV_walk_leftclose_v3a.subgait
@@ -1,0 +1,112 @@
+name: "left_close"
+version: "MV_walk_leftclose_v3a"
+description: "Final left step of the MIV walking gait, but then somewhat faster."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 448000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 525000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 560000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 700000000
+    joint_names: [left_hip_aa, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 840000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 399999999
+    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4668, 0.8727, 0.0436, 0.0, 0.1259, 0.1065, 0.0436]
+      velocities: [0.0, 1.3242, 0.0, 0.0, 0.0, -0.3233, -0.1294, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 448000000
+    - 
+      positions: [0.0, 0.5453, 0.857, 0.0436, 0.0, 0.1015, 0.0956, 0.0436]
+      velocities: [0.0, 0.5757, -0.4028, 0.0, 0.0, -0.2806, -0.1401, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 525000000
+    - 
+      positions: [0.0, 0.5585, 0.8427, 0.0436, 0.0, 0.0933, 0.0913, 0.0436]
+      velocities: [0.0, 0.1396, -0.544, 0.0, 0.0, -0.2616, -0.1431, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 560000000
+    - 
+      positions: [0.0, 0.5271, 0.727, 0.0436, 0.0, 0.0638, 0.0706, 0.0436]
+      velocities: [0.0, -0.5614, -1.0567, 0.0, 0.0, -0.1511, -0.1496, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 700000000
+    - 
+      positions: [0.0, 0.4126, 0.556, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
+      velocities: [0.0, -1.0162, -1.328, 0.0, 0.0, 0.0, -0.1439, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 840000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 399999999
+duration: 
+  secs: 1
+  nsecs: 399999999
+sounds: []

--- a/march_gait_files/airgait-v/walk/right_close/MV_walk_rightclose_v3a.subgait
+++ b/march_gait_files/airgait-v/walk/right_close/MV_walk_rightclose_v3a.subgait
@@ -1,0 +1,112 @@
+name: "right_close"
+version: "MV_walk_rightclose_v3a"
+description: "The MIV right close gait, but then somewhat faster."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 448000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 525000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 560000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 700000000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 840000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 399999999
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4668, 0.8727, 0.0436, 0.0, 0.1259, 0.1065, 0.0436]
+      velocities: [0.0, 1.3242, 0.0, 0.0, 0.0, -0.3233, -0.1294, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 448000000
+    - 
+      positions: [0.0, 0.5453, 0.857, 0.0436, 0.0, 0.1015, 0.0956, 0.0436]
+      velocities: [0.0, 0.5757, -0.4028, 0.0, 0.0, -0.2806, -0.1401, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 525000000
+    - 
+      positions: [0.0, 0.5585, 0.8427, 0.0436, 0.0, 0.0933, 0.0913, 0.0436]
+      velocities: [0.0, 0.1396, -0.544, 0.0, 0.0, -0.2616, -0.1431, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 560000000
+    - 
+      positions: [0.0, 0.5271, 0.727, 0.0436, 0.0, 0.0638, 0.0706, 0.0436]
+      velocities: [0.0, -0.5614, -1.0567, 0.0, 0.0, -0.1511, -0.1496, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 700000000
+    - 
+      positions: [0.0, 0.4126, 0.556, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
+      velocities: [0.0, -1.0162, -1.328, 0.0, 0.0, 0.0, -0.1439, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 840000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 399999999
+duration: 
+  secs: 1
+  nsecs: 399999999
+sounds: []


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
--> As the closing steps of walk version 3 seemed a little aggressive during the last groundgait sessions, I made the closings steps a little slower and called these versions 3a. These subgaits are now 1.4 seconds instead of 1.3 seconds. I already set these subgaits default in the gait directory airgait-v.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
--> Walk left_close and right_close version 3a default in airgait-v.

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
