### PR TITLE
Fix/rt first middle step smaller

### DIFF
--- a/march_gait_files/airgait-v/default.yaml
+++ b/march_gait_files/airgait-v/default.yaml
@@ -13,7 +13,7 @@ gaits:
   rough_terrain_middle_steps: {right_open: MV_RT_middlestep_rightopen_v2, left_swing: MV_RT_middlestep_leftswing_v2,
                                right_swing: MV_RT_middlestep_rightswing_v2, left_close: MV_RT_middlestep_leftclose_v3}
   rough_terrain_first_middle_step: {right_open: MV_RT_first_middlestep_rightopen_v2,
-                                    left_close: MV_RT_first_middlestep_leftclose_v2}
+                                    left_close: MV_RT_first_middlestep_leftclose_v3}
   rough_terrain_second_middle_step: {right_open: MV_RT_second_middlestep_rightopen_v1,
                                      left_close: MV_RT_second_middlestep_leftclose_v1}
   rough_terrain_third_middle_step: {right_open: MV_RT_third_middlestep_rightopen_v2,

--- a/march_gait_files/airgait-v/rough_terrain_first_middle_step/left_close/MV_RT_first_middlestep_leftclose_v3.subgait
+++ b/march_gait_files/airgait-v/rough_terrain_first_middle_step/left_close/MV_RT_first_middlestep_leftclose_v3.subgait
@@ -1,0 +1,125 @@
+name: "left_close"
+version: "MV_RT_first_middlestep_leftclose_v3"
+description: "The right knee extends later to prevent slipping off the beam."
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 200000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 880000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  62300000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 320000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 760000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 200000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.6391, 0.7696, 0.0436, 0.0, -0.2016, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, -0.5236, 0.0, 0.0, -0.0833, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.6222, 0.7418, 0.0436, 0.0, -0.1568, 0.2739, 0.0436]
+      velocities: [0.0, -0.1637, -0.5236, 0.0, 0.0, 0.4974, 1.2399, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 200000000
+    - 
+      positions: [0.0, 0.3834, 0.2094, 0.0436, 0.0, 0.4697, 1.3799, 0.0436]
+      velocities: [0.0, -0.4755, -0.1745, 0.0, 0.0, 0.9542, 0.8184, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 880000000
+    - 
+      positions: [0.0, 0.3253, 0.1872, 0.0436, 0.0, 0.5751, 1.4312, 0.0436]
+      velocities: [0.0, -0.4912, -0.194, 0.0, 0.0, 0.7914, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, 0.2946, 0.1749, 0.0436, 0.0, 0.621, 1.4229, 0.0436]
+      velocities: [0.0, -0.4947, -0.2014, 0.0, 0.0, 0.678, -0.2633, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  62300000
+    - 
+      positions: [0.0, 0.1684, 0.121, 0.0436, 0.0, 0.7156, 1.2253, 0.0436]
+      velocities: [0.0, -0.4755, -0.2115, 0.0, 0.0, 0.0, -1.241, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 320000000
+    - 
+      positions: [0.0, -0.0118, 0.0372, 0.0436, 0.0, 0.3142, 0.384, 0.0436]
+      velocities: [0.0, -0.317, -0.1533, 0.0, 0.0, -1.3686, -2.4958, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 760000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 200000000
+duration: 
+  secs: 2
+  nsecs: 200000000
+sounds: []

--- a/march_gait_files/test_versions-v/rough_terrain_first_middle_step/left_close/MV_RT_first_middlestep_leftclose_v3.subgait
+++ b/march_gait_files/test_versions-v/rough_terrain_first_middle_step/left_close/MV_RT_first_middlestep_leftclose_v3.subgait
@@ -1,0 +1,125 @@
+name: "left_close"
+version: "MV_RT_first_middlestep_leftclose_v3"
+description: "The right knee extends later to prevent slipping off the beam."
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 200000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 880000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:         0
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  62300000
+    joint_names: [right_hip_aa, left_hip_aa]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 320000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 760000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 2
+      nsecs: 200000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0, 0.6391, 0.7696, 0.0436, 0.0, -0.2016, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, -0.5236, 0.0, 0.0, -0.0833, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.6222, 0.7418, 0.0436, 0.0, -0.1568, 0.2739, 0.0436]
+      velocities: [0.0, -0.1637, -0.5236, 0.0, 0.0, 0.4974, 1.2399, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 200000000
+    - 
+      positions: [0.0, 0.3834, 0.2094, 0.0436, 0.0, 0.4697, 1.3799, 0.0436]
+      velocities: [0.0, -0.4755, -0.1745, 0.0, 0.0, 0.9542, 0.8184, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 880000000
+    - 
+      positions: [0.0, 0.3253, 0.1872, 0.0436, 0.0, 0.5751, 1.4312, 0.0436]
+      velocities: [0.0, -0.4912, -0.194, 0.0, 0.0, 0.7914, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:         0
+    - 
+      positions: [0.0, 0.2946, 0.1749, 0.0436, 0.0, 0.621, 1.4229, 0.0436]
+      velocities: [0.0, -0.4947, -0.2014, 0.0, 0.0, 0.678, -0.2633, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  62300000
+    - 
+      positions: [0.0, 0.1684, 0.121, 0.0436, 0.0, 0.7156, 1.2253, 0.0436]
+      velocities: [0.0, -0.4755, -0.2115, 0.0, 0.0, 0.0, -1.241, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 320000000
+    - 
+      positions: [0.0, -0.0118, 0.0372, 0.0436, 0.0, 0.3142, 0.384, 0.0436]
+      velocities: [0.0, -0.317, -0.1533, 0.0, 0.0, -1.3686, -2.4958, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 760000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 2
+        nsecs: 200000000
+duration: 
+  secs: 2
+  nsecs: 200000000
+sounds: []


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
--> Add a version 3 of the Rough Terrain first middle step left_close in the gait directory airgait-v. The only difference compared to version 2 is that the right knee extends after 0.15 seconds instead of immediately at the start of the subgait. This is because we saw that the knee extended before the foot was placed on the beam, resulting in a too large step.

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
