### PR TITLE
Fix/new version tilted path single step

### DIFF
--- a/march_gait_files/airgait-v/tilted_path_left_single_step/right_open/MV_TP_left_singlestep_rightopen_v10.subgait
+++ b/march_gait_files/airgait-v/tilted_path_left_single_step/right_open/MV_TP_left_singlestep_rightopen_v10.subgait
@@ -1,0 +1,138 @@
+name: "right_open"
+version: "MV_TP_left_singlestep_rightopen_v10"
+description: "Same as v9 but with dorsal flexion in ankle instead of plantar flexion"
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 250000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 400300000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:    299999
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0873, -0.0873, 0.0, 0.0436, -0.0524, 0.5236, 0.8203, 0.1309]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0873, 0.1772, 0.377, 0.1047, -0.0524, 0.5107, 0.8282, 0.1309]
+      velocities: [0.0, 1.7455, 2.3604, 0.1745, 0.0, -0.0969, 0.057, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 250000000
+    - 
+      positions: [0.0873, 0.4481, 0.7139, 0.1222, -0.0524, 0.493, 0.8382, 0.1309]
+      velocities: [0.0, 1.7246, 1.886, 0.0355, 0.0, -0.1366, 0.0735, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 400300000
+    - 
+      positions: [0.0873, 0.6548, 0.8727, 0.1192, -0.0524, 0.4704, 0.8496, 0.1309]
+      velocities: [0.0, 0.9047, 0.0, -0.068, 0.0, -0.1621, 0.0766, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [0.0873, 0.6981, 0.851, 0.1122, -0.0524, 0.4571, 0.8556, 0.1309]
+      velocities: [0.0, 0.1396, -0.5237, -0.1062, 0.0, -0.17, 0.0728, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [0.0873, 0.5973, 0.412, 0.0611, -0.0524, 0.3943, 0.8726, 0.1309]
+      velocities: [0.0, -0.562, -1.4316, -0.1272, 0.0, -0.1551, 0.0058, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:    299999
+    - 
+      positions: [0.0873, 0.5861, 0.384, 0.0587, -0.0524, 0.3913, 0.8727, 0.1309]
+      velocities: [0.0, -0.5788, -1.4101, -0.1157, 0.0, -0.1519, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [0.0873, 0.3834, 0.0969, 0.0434, -0.0524, 0.354, 0.8727, 0.1309]
+      velocities: [0.0, -0.5529, 0.0, -0.0022, 0.0, -0.0628, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0873, 0.3142, 0.1396, 0.0436, -0.0524, 0.3491, 0.8727, 0.1309]
+      velocities: [0.0, -0.3491, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/tilted_path_left_single_step/right_open/MV_TP_left_singlestep_rightopen_v11.subgait
+++ b/march_gait_files/airgait-v/tilted_path_left_single_step/right_open/MV_TP_left_singlestep_rightopen_v11.subgait
@@ -1,0 +1,99 @@
+name: "right_open"
+version: "MV_TP_left_singlestep_rightopen_v11"
+description: "Same as v9 but with no ankle movement"
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0873, -0.0873, 0.0, 0.0436, -0.0524, 0.5236, 0.8203, 0.1309]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0873, 0.6548, 0.8727, 0.0436, -0.0524, 0.4704, 0.8496, 0.1309]
+      velocities: [0.0, 0.9047, 0.0, 0.0, 0.0, -0.1621, 0.0766, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [0.0873, 0.6981, 0.851, 0.0436, -0.0524, 0.4571, 0.8556, 0.1309]
+      velocities: [0.0, 0.1396, -0.5237, 0.0, 0.0, -0.17, 0.0728, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [0.0873, 0.5861, 0.384, 0.0436, -0.0524, 0.3913, 0.8727, 0.1309]
+      velocities: [0.0, -0.5788, -1.4101, 0.0, 0.0, -0.1519, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [0.0873, 0.3834, 0.0969, 0.0436, -0.0524, 0.354, 0.8727, 0.1309]
+      velocities: [0.0, -0.5529, 0.0, 0.0, 0.0, -0.0628, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0873, 0.3142, 0.1396, 0.0436, -0.0524, 0.3491, 0.8727, 0.1309]
+      velocities: [0.0, -0.3491, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/tilted_path_left_single_step/right_open/MV_TP_left_singlestep_rightopen_v9.subgait
+++ b/march_gait_files/airgait-v/tilted_path_left_single_step/right_open/MV_TP_left_singlestep_rightopen_v9.subgait
@@ -1,0 +1,113 @@
+name: "right_open"
+version: "MV_TP_left_singlestep_rightopen_v9"
+description: "Earlier hip flexion and a toe off moment to make it easier to get the foot off the\
+  \ grass."
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 300000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0873, -0.0873, 0.0, 0.0436, -0.0524, 0.5236, 0.8203, 0.1309]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0873, 0.2669, 0.4957, -0.1231, -0.0524, 0.5055, 0.8312, 0.1309]
+      velocities: [0.0, 1.8278, 2.3604, 0.0, 0.0, -0.1117, 0.064, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 300000000
+    - 
+      positions: [0.0873, 0.6548, 0.8727, -0.1044, -0.0524, 0.4704, 0.8496, 0.1309]
+      velocities: [0.0, 0.9047, 0.0, 0.1375, 0.0, -0.1621, 0.0766, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [0.0873, 0.6981, 0.851, -0.0922, -0.0524, 0.4571, 0.8556, 0.1309]
+      velocities: [0.0, 0.1396, -0.5237, 0.1662, 0.0, -0.17, 0.0728, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [0.0873, 0.5861, 0.384, -0.0151, -0.0524, 0.3913, 0.8727, 0.1309]
+      velocities: [0.0, -0.5788, -1.4101, 0.2, 0.0, -0.1519, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [0.0873, 0.3834, 0.0969, 0.0364, -0.0524, 0.354, 0.8727, 0.1309]
+      velocities: [0.0, -0.5529, 0.0, 0.0912, 0.0, -0.0628, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0873, 0.3142, 0.1396, 0.0436, -0.0524, 0.3491, 0.8727, 0.1309]
+      velocities: [0.0, -0.3491, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/tilted_path_right_single_step/left_open/MV_TP_right_singlestep_leftopen_v10.subgait
+++ b/march_gait_files/airgait-v/tilted_path_right_single_step/left_open/MV_TP_right_singlestep_leftopen_v10.subgait
@@ -1,0 +1,138 @@
+name: "left_open"
+version: "MV_TP_right_singlestep_leftopen_v10"
+description: "Same as v9 but with dorsal flexion in the ankle"
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 250000000
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 400300000
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:    299999
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [-0.0524, 0.5236, 0.8203, 0.1309, 0.0873, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [-0.0524, 0.5107, 0.8282, 0.1309, 0.0873, 0.1772, 0.377, 0.1047]
+      velocities: [0.0, -0.0969, 0.057, 0.0, 0.0, 1.7455, 2.3604, 0.1745]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 250000000
+    - 
+      positions: [-0.0524, 0.493, 0.8382, 0.1309, 0.0873, 0.4481, 0.7139, 0.1222]
+      velocities: [0.0, -0.1366, 0.0735, 0.0, 0.0, 1.7246, 1.886, 0.0355]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 400300000
+    - 
+      positions: [-0.0524, 0.4704, 0.8496, 0.1309, 0.0873, 0.6548, 0.8727, 0.1192]
+      velocities: [0.0, -0.1621, 0.0766, 0.0, 0.0, 0.9047, 0.0, -0.068]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [-0.0524, 0.4571, 0.8556, 0.1309, 0.0873, 0.6981, 0.851, 0.1122]
+      velocities: [0.0, -0.17, 0.0728, 0.0, 0.0, 0.1396, -0.5237, -0.1062]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [-0.0524, 0.3943, 0.8726, 0.1309, 0.0873, 0.5973, 0.412, 0.0611]
+      velocities: [0.0, -0.1551, 0.0058, 0.0, 0.0, -0.562, -1.4316, -0.1272]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:    299999
+    - 
+      positions: [-0.0524, 0.3913, 0.8727, 0.1309, 0.0873, 0.5861, 0.384, 0.0587]
+      velocities: [0.0, -0.1519, 0.0, 0.0, 0.0, -0.5788, -1.4101, -0.1157]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [-0.0524, 0.354, 0.8727, 0.1309, 0.0873, 0.3834, 0.0969, 0.0434]
+      velocities: [0.0, -0.0628, 0.0, 0.0, 0.0, -0.5529, 0.0, -0.0022]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [-0.0524, 0.3491, 0.8727, 0.1309, 0.0873, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/tilted_path_right_single_step/left_open/MV_TP_right_singlestep_leftopen_v11.subgait
+++ b/march_gait_files/airgait-v/tilted_path_right_single_step/left_open/MV_TP_right_singlestep_leftopen_v11.subgait
@@ -1,0 +1,99 @@
+name: "left_open"
+version: "MV_TP_right_singlestep_leftopen_v11"
+description: "Same as v9 but with no ankle movement"
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [-0.0524, 0.5236, 0.8203, 0.1309, 0.0873, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [-0.0524, 0.4704, 0.8496, 0.1309, 0.0873, 0.6548, 0.8727, 0.0436]
+      velocities: [0.0, -0.1621, 0.0766, 0.0, 0.0, 0.9047, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [-0.0524, 0.4571, 0.8556, 0.1309, 0.0873, 0.6981, 0.851, 0.0436]
+      velocities: [0.0, -0.17, 0.0728, 0.0, 0.0, 0.1396, -0.5237, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [-0.0524, 0.3913, 0.8727, 0.1309, 0.0873, 0.5861, 0.384, 0.0436]
+      velocities: [0.0, -0.1519, 0.0, 0.0, 0.0, -0.5788, -1.4101, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [-0.0524, 0.354, 0.8727, 0.1309, 0.0873, 0.3834, 0.0969, 0.0436]
+      velocities: [0.0, -0.0628, 0.0, 0.0, 0.0, -0.5529, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [-0.0524, 0.3491, 0.8727, 0.1309, 0.0873, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/airgait-v/tilted_path_right_single_step/left_open/MV_TP_right_singlestep_leftopen_v9.subgait
+++ b/march_gait_files/airgait-v/tilted_path_right_single_step/left_open/MV_TP_right_singlestep_leftopen_v9.subgait
@@ -1,0 +1,113 @@
+name: "left_open"
+version: "MV_TP_right_singlestep_leftopen_v9"
+description: "Earlier hip flexion and a toe off moment to make it easier to get the foot off the\
+  \ grass."
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 300000000
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [-0.0524, 0.5236, 0.8203, 0.1309, 0.0873, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [-0.0524, 0.5055, 0.8312, 0.1309, 0.0873, 0.2669, 0.4957, -0.1231]
+      velocities: [0.0, -0.1117, 0.064, 0.0, 0.0, 1.8278, 2.3604, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 300000000
+    - 
+      positions: [-0.0524, 0.4704, 0.8496, 0.1309, 0.0873, 0.6548, 0.8727, -0.1044]
+      velocities: [0.0, -0.1621, 0.0766, 0.0, 0.0, 0.9047, 0.0, 0.1375]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [-0.0524, 0.4571, 0.8556, 0.1309, 0.0873, 0.6981, 0.851, -0.0922]
+      velocities: [0.0, -0.17, 0.0728, 0.0, 0.0, 0.1396, -0.5237, 0.1662]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [-0.0524, 0.3913, 0.8727, 0.1309, 0.0873, 0.5861, 0.384, -0.0151]
+      velocities: [0.0, -0.1519, 0.0, 0.0, 0.0, -0.5788, -1.4101, 0.2]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [-0.0524, 0.354, 0.8727, 0.1309, 0.0873, 0.3834, 0.0969, 0.0364]
+      velocities: [0.0, -0.0628, 0.0, 0.0, 0.0, -0.5529, 0.0, 0.0912]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [-0.0524, 0.3491, 0.8727, 0.1309, 0.0873, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/test_versions-v/tilted_path_left_single_step/right_open/MV_TP_left_singlestep_rightopen_v10.subgait
+++ b/march_gait_files/test_versions-v/tilted_path_left_single_step/right_open/MV_TP_left_singlestep_rightopen_v10.subgait
@@ -1,0 +1,138 @@
+name: "right_open"
+version: "MV_TP_left_singlestep_rightopen_v10"
+description: "Same as v9 but with dorsal flexion in ankle instead of plantar flexion"
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 250000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 400300000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:    299999
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0873, -0.0873, 0.0, 0.0436, -0.0524, 0.5236, 0.8203, 0.1309]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0873, 0.1772, 0.377, 0.1047, -0.0524, 0.5107, 0.8282, 0.1309]
+      velocities: [0.0, 1.7455, 2.3604, 0.1745, 0.0, -0.0969, 0.057, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 250000000
+    - 
+      positions: [0.0873, 0.4481, 0.7139, 0.1222, -0.0524, 0.493, 0.8382, 0.1309]
+      velocities: [0.0, 1.7246, 1.886, 0.0355, 0.0, -0.1366, 0.0735, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 400300000
+    - 
+      positions: [0.0873, 0.6548, 0.8727, 0.1192, -0.0524, 0.4704, 0.8496, 0.1309]
+      velocities: [0.0, 0.9047, 0.0, -0.068, 0.0, -0.1621, 0.0766, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [0.0873, 0.6981, 0.851, 0.1122, -0.0524, 0.4571, 0.8556, 0.1309]
+      velocities: [0.0, 0.1396, -0.5237, -0.1062, 0.0, -0.17, 0.0728, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [0.0873, 0.5973, 0.412, 0.0611, -0.0524, 0.3943, 0.8726, 0.1309]
+      velocities: [0.0, -0.562, -1.4316, -0.1272, 0.0, -0.1551, 0.0058, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:    299999
+    - 
+      positions: [0.0873, 0.5861, 0.384, 0.0587, -0.0524, 0.3913, 0.8727, 0.1309]
+      velocities: [0.0, -0.5788, -1.4101, -0.1157, 0.0, -0.1519, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [0.0873, 0.3834, 0.0969, 0.0434, -0.0524, 0.354, 0.8727, 0.1309]
+      velocities: [0.0, -0.5529, 0.0, -0.0022, 0.0, -0.0628, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0873, 0.3142, 0.1396, 0.0436, -0.0524, 0.3491, 0.8727, 0.1309]
+      velocities: [0.0, -0.3491, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/test_versions-v/tilted_path_left_single_step/right_open/MV_TP_left_singlestep_rightopen_v11.subgait
+++ b/march_gait_files/test_versions-v/tilted_path_left_single_step/right_open/MV_TP_left_singlestep_rightopen_v11.subgait
@@ -1,0 +1,99 @@
+name: "right_open"
+version: "MV_TP_left_singlestep_rightopen_v11"
+description: "Same as v9 but with no ankle movement"
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0873, -0.0873, 0.0, 0.0436, -0.0524, 0.5236, 0.8203, 0.1309]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0873, 0.6548, 0.8727, 0.0436, -0.0524, 0.4704, 0.8496, 0.1309]
+      velocities: [0.0, 0.9047, 0.0, 0.0, 0.0, -0.1621, 0.0766, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [0.0873, 0.6981, 0.851, 0.0436, -0.0524, 0.4571, 0.8556, 0.1309]
+      velocities: [0.0, 0.1396, -0.5237, 0.0, 0.0, -0.17, 0.0728, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [0.0873, 0.5861, 0.384, 0.0436, -0.0524, 0.3913, 0.8727, 0.1309]
+      velocities: [0.0, -0.5788, -1.4101, 0.0, 0.0, -0.1519, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [0.0873, 0.3834, 0.0969, 0.0436, -0.0524, 0.354, 0.8727, 0.1309]
+      velocities: [0.0, -0.5529, 0.0, 0.0, 0.0, -0.0628, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0873, 0.3142, 0.1396, 0.0436, -0.0524, 0.3491, 0.8727, 0.1309]
+      velocities: [0.0, -0.3491, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/test_versions-v/tilted_path_left_single_step/right_open/MV_TP_left_singlestep_rightopen_v9.subgait
+++ b/march_gait_files/test_versions-v/tilted_path_left_single_step/right_open/MV_TP_left_singlestep_rightopen_v9.subgait
@@ -1,0 +1,113 @@
+name: "right_open"
+version: "MV_TP_left_singlestep_rightopen_v9"
+description: "Earlier hip flexion and a toe off moment to make it easier to get the foot off the\
+  \ grass."
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 300000000
+    joint_names: [right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [0.0873, -0.0873, 0.0, 0.0436, -0.0524, 0.5236, 0.8203, 0.1309]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0873, 0.2669, 0.4957, -0.1231, -0.0524, 0.5055, 0.8312, 0.1309]
+      velocities: [0.0, 1.8278, 2.3604, 0.0, 0.0, -0.1117, 0.064, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 300000000
+    - 
+      positions: [0.0873, 0.6548, 0.8727, -0.1044, -0.0524, 0.4704, 0.8496, 0.1309]
+      velocities: [0.0, 0.9047, 0.0, 0.1375, 0.0, -0.1621, 0.0766, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [0.0873, 0.6981, 0.851, -0.0922, -0.0524, 0.4571, 0.8556, 0.1309]
+      velocities: [0.0, 0.1396, -0.5237, 0.1662, 0.0, -0.17, 0.0728, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [0.0873, 0.5861, 0.384, -0.0151, -0.0524, 0.3913, 0.8727, 0.1309]
+      velocities: [0.0, -0.5788, -1.4101, 0.2, 0.0, -0.1519, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [0.0873, 0.3834, 0.0969, 0.0364, -0.0524, 0.354, 0.8727, 0.1309]
+      velocities: [0.0, -0.5529, 0.0, 0.0912, 0.0, -0.0628, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [0.0873, 0.3142, 0.1396, 0.0436, -0.0524, 0.3491, 0.8727, 0.1309]
+      velocities: [0.0, -0.3491, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/test_versions-v/tilted_path_right_single_step/left_open/MV_TP_right_singlestep_leftopen_v10.subgait
+++ b/march_gait_files/test_versions-v/tilted_path_right_single_step/left_open/MV_TP_right_singlestep_leftopen_v10.subgait
@@ -1,0 +1,138 @@
+name: "left_open"
+version: "MV_TP_right_singlestep_leftopen_v10"
+description: "Same as v9 but with dorsal flexion in the ankle"
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 250000000
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 400300000
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:    299999
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [-0.0524, 0.5236, 0.8203, 0.1309, 0.0873, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [-0.0524, 0.5107, 0.8282, 0.1309, 0.0873, 0.1772, 0.377, 0.1047]
+      velocities: [0.0, -0.0969, 0.057, 0.0, 0.0, 1.7455, 2.3604, 0.1745]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 250000000
+    - 
+      positions: [-0.0524, 0.493, 0.8382, 0.1309, 0.0873, 0.4481, 0.7139, 0.1222]
+      velocities: [0.0, -0.1366, 0.0735, 0.0, 0.0, 1.7246, 1.886, 0.0355]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 400300000
+    - 
+      positions: [-0.0524, 0.4704, 0.8496, 0.1309, 0.0873, 0.6548, 0.8727, 0.1192]
+      velocities: [0.0, -0.1621, 0.0766, 0.0, 0.0, 0.9047, 0.0, -0.068]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [-0.0524, 0.4571, 0.8556, 0.1309, 0.0873, 0.6981, 0.851, 0.1122]
+      velocities: [0.0, -0.17, 0.0728, 0.0, 0.0, 0.1396, -0.5237, -0.1062]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [-0.0524, 0.3943, 0.8726, 0.1309, 0.0873, 0.5973, 0.412, 0.0611]
+      velocities: [0.0, -0.1551, 0.0058, 0.0, 0.0, -0.562, -1.4316, -0.1272]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:    299999
+    - 
+      positions: [-0.0524, 0.3913, 0.8727, 0.1309, 0.0873, 0.5861, 0.384, 0.0587]
+      velocities: [0.0, -0.1519, 0.0, 0.0, 0.0, -0.5788, -1.4101, -0.1157]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [-0.0524, 0.354, 0.8727, 0.1309, 0.0873, 0.3834, 0.0969, 0.0434]
+      velocities: [0.0, -0.0628, 0.0, 0.0, 0.0, -0.5529, 0.0, -0.0022]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [-0.0524, 0.3491, 0.8727, 0.1309, 0.0873, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/test_versions-v/tilted_path_right_single_step/left_open/MV_TP_right_singlestep_leftopen_v11.subgait
+++ b/march_gait_files/test_versions-v/tilted_path_right_single_step/left_open/MV_TP_right_singlestep_leftopen_v11.subgait
@@ -1,0 +1,99 @@
+name: "left_open"
+version: "MV_TP_right_singlestep_leftopen_v11"
+description: "Same as v9 but with no ankle movement"
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [-0.0524, 0.5236, 0.8203, 0.1309, 0.0873, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [-0.0524, 0.4704, 0.8496, 0.1309, 0.0873, 0.6548, 0.8727, 0.0436]
+      velocities: [0.0, -0.1621, 0.0766, 0.0, 0.0, 0.9047, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [-0.0524, 0.4571, 0.8556, 0.1309, 0.0873, 0.6981, 0.851, 0.0436]
+      velocities: [0.0, -0.17, 0.0728, 0.0, 0.0, 0.1396, -0.5237, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [-0.0524, 0.3913, 0.8727, 0.1309, 0.0873, 0.5861, 0.384, 0.0436]
+      velocities: [0.0, -0.1519, 0.0, 0.0, 0.0, -0.5788, -1.4101, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [-0.0524, 0.354, 0.8727, 0.1309, 0.0873, 0.3834, 0.0969, 0.0436]
+      velocities: [0.0, -0.0628, 0.0, 0.0, 0.0, -0.5529, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [-0.0524, 0.3491, 0.8727, 0.1309, 0.0873, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []

--- a/march_gait_files/test_versions-v/tilted_path_right_single_step/left_open/MV_TP_right_singlestep_leftopen_v9.subgait
+++ b/march_gait_files/test_versions-v/tilted_path_right_single_step/left_open/MV_TP_right_singlestep_leftopen_v9.subgait
@@ -1,0 +1,113 @@
+name: "left_open"
+version: "MV_TP_right_singlestep_leftopen_v9"
+description: "Earlier hip flexion and a toe off moment to make it easier to get the foot off the\
+  \ grass."
+gait_type: ''
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 300000000
+    joint_names: [left_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 550000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 630000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs:  20000000
+    joint_names: [right_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 350000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 500000000
+    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
+  left_ankle]
+  points: 
+    - 
+      positions: [-0.0524, 0.5236, 0.8203, 0.1309, 0.0873, -0.0873, 0.0, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [-0.0524, 0.5055, 0.8312, 0.1309, 0.0873, 0.2669, 0.4957, -0.1231]
+      velocities: [0.0, -0.1117, 0.064, 0.0, 0.0, 1.8278, 2.3604, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 300000000
+    - 
+      positions: [-0.0524, 0.4704, 0.8496, 0.1309, 0.0873, 0.6548, 0.8727, -0.1044]
+      velocities: [0.0, -0.1621, 0.0766, 0.0, 0.0, 0.9047, 0.0, 0.1375]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 550000000
+    - 
+      positions: [-0.0524, 0.4571, 0.8556, 0.1309, 0.0873, 0.6981, 0.851, -0.0922]
+      velocities: [0.0, -0.17, 0.0728, 0.0, 0.0, 0.1396, -0.5237, 0.1662]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 630000000
+    - 
+      positions: [-0.0524, 0.3913, 0.8727, 0.1309, 0.0873, 0.5861, 0.384, -0.0151]
+      velocities: [0.0, -0.1519, 0.0, 0.0, 0.0, -0.5788, -1.4101, 0.2]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs:  20000000
+    - 
+      positions: [-0.0524, 0.354, 0.8727, 0.1309, 0.0873, 0.3834, 0.0969, 0.0364]
+      velocities: [0.0, -0.0628, 0.0, 0.0, 0.0, -0.5529, 0.0, 0.0912]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 350000000
+    - 
+      positions: [-0.0524, 0.3491, 0.8727, 0.1309, 0.0873, 0.3142, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 500000000
+duration: 
+  secs: 1
+  nsecs: 500000000
+sounds: []


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->



## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
During the TP training with Sjaan, we found out that she can't lift her foot off the grass to initiate a single step. We tried to take a step without lifting the foot first, but then the foot didn't come off the grass at all. Therefore, we made three new version in which the leg doesn't have a (small) back swing, but will lift immediately off the grass so hopefully the foot won't stick into the grass anymore. The differences in the versions are related to the ankle movements.

The new versions (both left and right) are already in de airgait-v folder
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
Added three new versions of the right_open subgait of the tilted path single steps in both directions:

- v9: plantar flexion is used to generate a toe off moment
- v10: dorsal flexion is used to prevent the nose of the shoe to stick into the grass
- v11: no ankle movement is used during the swing
<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
