### PR TITLE
New gaits to training-v

### DIFF
--- a/march_gait_files/training-v/default.yaml
+++ b/march_gait_files/training-v/default.yaml
@@ -7,6 +7,7 @@ gaits:
   side_step_right_small: {right_open: MIV_final, left_close: MIV_final}
   single_step_normal: {right_open: MIV_final, left_close: MIV_final}
   single_step_small: {right_open: MIV_final_v2, left_close: MIV_final}
+  single_step_mini: {right_open: MV_singlemini_rightopen_v1, left_close: MV_singlemini_leftclose_v1}
   sit: {sit_down: MIV_final, sit_home: MIV_final}
   stand: {prepare_stand_up: MIV_final, stand_up: MIV_final}
   sofa_sit: {sit_down: MIV_final, sit_home: MIV_final}

--- a/march_gait_files/training-v/default.yaml
+++ b/march_gait_files/training-v/default.yaml
@@ -23,7 +23,7 @@ gaits:
                 right_close: MV_stairsdown_rightclose_v9}
   walk: {right_open: MIV_final, left_swing: MIV_final, right_swing: MIV_final,
          left_close: MIV_final, right_close: MIV_final}
-  slalom_walk: {right_open: MIV_final, left_swing: MIV_final, right_swing: MIV_final,
+  slalom_walk: {right_open: MIV_final, left_swing: MV_slalom_leftswing_v2, right_swing: MV_slalom_rightswing_v2,
                 left_close: MIV_final, right_close: MIV_final}
   rough_terrain_high_step: {right_open: MV_RT_highstep_rightopen_v7, left_close: MV_RT_highstep_leftclose_v8}
   rough_terrain_middle_steps: {right_open: MV_RT_middlestep_rightopen_v2, left_swing: MV_RT_middlestep_leftswing_v2,

--- a/march_gait_files/training-v/default.yaml
+++ b/march_gait_files/training-v/default.yaml
@@ -12,9 +12,9 @@ gaits:
   stand: {prepare_stand_up: MIV_final, stand_up: MIV_final}
   sofa_sit: {sit_down: MIV_final, sit_home: MIV_final}
   sofa_stand: {prepare_stand_up: MIV_final, stand_up: MIV_final}
-  stairs_up: {right_open: MV_stairsup_rightopen_v15a, left_swing: MV_stairsup_leftswing_v15,
-              right_swing: MV_stairsup_rightswing_v15, left_close: MV_stairsup_leftclose_v15,
-              right_close: MV_stairsup_rightclose_v15}
+  stairs_up: {right_open: MV_stairsup_rightopen_v17, left_swing: MV_stairsup_leftswing_v17,
+              right_swing: MV_stairsup_rightswing_v17, left_close: MV_stairsup_leftclose_v17,
+              right_close: MV_stairsup_rightclose_v17}
   stairs_up_single_step: {right_open: MV_stairsup_single_rightopen_v7, left_close: MV_stairsup_single_leftclose_v7}
   stairs_down_single_step: {right_open: MV_stairsdown_single_rightopen_v4,
                             left_close: MV_stairsdown_single_leftclose_v4}

--- a/march_gait_files/training-v/single_step_mini/left_close/MV_singlemini_leftclose_v1.subgait
+++ b/march_gait_files/training-v/single_step_mini/left_close/MV_singlemini_leftclose_v1.subgait
@@ -1,0 +1,83 @@
+description: Super small single step for rough terrain
+duration: {nsecs: 500000000, secs: 1}
+gait_type: walk_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 562500000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 750000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: -0.0
+  left_hip_fe:
+  - position: -0.1222
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.5585
+    time_from_start: {nsecs: 600000000, secs: 0}
+    velocity: 0.1443
+  - position: -0.0873
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: 0.0
+  left_knee:
+  - position: 0.1396
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 480000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 562500000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 750000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: -0.0
+  right_hip_fe:
+  - position: 0.192
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: -0.3491
+  - position: 0.0524
+    time_from_start: {nsecs: 900000000, secs: 0}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: 0.0
+  right_knee:
+  - position: 0.1396
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: 0.0
+name: left_close
+version: MV_singlemini_leftclose_v1

--- a/march_gait_files/training-v/single_step_mini/right_open/MV_singlemini_rightopen_v1.subgait
+++ b/march_gait_files/training-v/single_step_mini/right_open/MV_singlemini_rightopen_v1.subgait
@@ -1,0 +1,86 @@
+description: The right open gait for the MIV walking gait with less hip flexion
+duration: {nsecs: 500000000, secs: 1}
+gait_type: walk_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 562400000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 750000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: -0.0
+  left_hip_fe:
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: -0.1222
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: 0.0
+  left_knee:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 20000000, secs: 1}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 562400000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 750000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: -0.0
+  right_hip_fe:
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.3491
+    time_from_start: {nsecs: 675000000, secs: 0}
+    velocity: 0.1582
+  - position: 0.192
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: -0.3491
+  right_knee:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 500000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0969
+    time_from_start: {nsecs: 350000000, secs: 1}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 500000000, secs: 1}
+    velocity: 0.0
+name: right_open
+version: MV_singlemini_rightopen_v1

--- a/march_gait_files/training-v/single_step_mini/single_step_mini.gait
+++ b/march_gait_files/training-v/single_step_mini/single_step_mini.gait
@@ -1,0 +1,8 @@
+name: single_step_mini
+subgaits:
+  left_close:
+    to: end
+  right_open:
+    to: left_close
+  start:
+    to: right_open

--- a/march_gait_files/training-v/slalom_walk/left_swing/MV_slalom_leftswing_v2.subgait
+++ b/march_gait_files/training-v/slalom_walk/left_swing/MV_slalom_leftswing_v2.subgait
@@ -1,0 +1,89 @@
+description: Slower swings.
+duration: {nsecs: 300000000, secs: 1}
+gait_type: walk_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 487500000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 650000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: -0.0
+  left_hip_fe:
+  - position: -0.1667
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.4887
+    time_from_start: {nsecs: 780000000, secs: 0}
+    velocity: 0.145
+  - position: 0.288
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: -0.3491
+  left_knee:
+  - position: 0.1396
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 546000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0969
+    time_from_start: {nsecs: 169999999, secs: 1}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 487500000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 650000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: -0.0
+  right_hip_fe:
+  - position: 0.288
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: -0.3491
+  - position: -0.1667
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: 0.0
+  right_knee:
+  - position: 0.1396
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.2094
+    time_from_start: {nsecs: 260000000, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 884000000, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: 0.0
+name: left_swing
+version: MV_slalom_leftswing_v2

--- a/march_gait_files/training-v/slalom_walk/right_swing/MV_slalom_rightswing_v2.subgait
+++ b/march_gait_files/training-v/slalom_walk/right_swing/MV_slalom_rightswing_v2.subgait
@@ -1,0 +1,89 @@
+description: Slower swings.
+duration: {nsecs: 300000000, secs: 1}
+gait_type: walk_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 487500000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 650000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: -0.0
+  left_hip_fe:
+  - position: 0.288
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: -0.3491
+  - position: -0.1667
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: 0.0
+  left_knee:
+  - position: 0.1396
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.2094
+    time_from_start: {nsecs: 260000000, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 884000000, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 487500000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 650000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: -0.0
+  right_hip_fe:
+  - position: -0.1667
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.4887
+    time_from_start: {nsecs: 780000000, secs: 0}
+    velocity: 0.145
+  - position: 0.288
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: -0.3491
+  right_knee:
+  - position: 0.1396
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 546000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0969
+    time_from_start: {nsecs: 169999999, secs: 1}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 300000000, secs: 1}
+    velocity: 0.0
+name: right_swing
+version: MV_slalom_rightswing_v2

--- a/march_gait_files/training-v/stairs_up/left_close/MV_stairsup_leftclose_v17.subgait
+++ b/march_gait_files/training-v/stairs_up/left_close/MV_stairsup_leftclose_v17.subgait
@@ -1,0 +1,71 @@
+description: Left close of the stairs up gait
+duration: {nsecs: 0, secs: 3}
+gait_type: stairs_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  left_hip_fe:
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.1454
+  - position: 0.9599
+    time_from_start: {nsecs: 527400000, secs: 1}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  left_knee:
+  - position: 0.2443
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.5818
+  - position: 1.4835
+    time_from_start: {nsecs: 199999999, secs: 1}
+    velocity: 0.0
+  - position: 1.2008
+    time_from_start: {nsecs: 800000000, secs: 1}
+    velocity: -1.1109
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_hip_fe:
+  - position: 0.3491
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_knee:
+  - position: 0.4189
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+name: left_close
+version: MV_stairsup_leftclose_v17

--- a/march_gait_files/training-v/stairs_up/left_swing/MV_stairsup_leftswing_v17.subgait
+++ b/march_gait_files/training-v/stairs_up/left_swing/MV_stairsup_leftswing_v17.subgait
@@ -1,0 +1,72 @@
+description: Left swing of the stairs up gait in which the left leg stretches already
+  in this subgait
+duration: {nsecs: 0, secs: 3}
+gait_type: stairs_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  left_hip_fe:
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.1454
+  - position: 1.309
+    time_from_start: {nsecs: 399999999, secs: 1}
+    velocity: -0.1018
+  - position: 0.3491
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  left_knee:
+  - position: 0.2443
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.5818
+  - position: 1.7453
+    time_from_start: {nsecs: 100000000, secs: 1}
+    velocity: -0.4363
+  - position: 0.4189
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_hip_fe:
+  - position: 0.3491
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.1454
+  right_knee:
+  - position: 0.4189
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 490000000, secs: 2}
+    velocity: 0.0
+  - position: 0.2443
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.5818
+name: left_swing
+version: MV_stairsup_leftswing_v17

--- a/march_gait_files/training-v/stairs_up/right_close/MV_stairsup_rightclose_v17.subgait
+++ b/march_gait_files/training-v/stairs_up/right_close/MV_stairsup_rightclose_v17.subgait
@@ -1,0 +1,71 @@
+description: Right close of the stairs up gait
+duration: {nsecs: 0, secs: 3}
+gait_type: stairs_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  left_hip_fe:
+  - position: 0.3491
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  left_knee:
+  - position: 0.4189
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_hip_fe:
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.1454
+  - position: 0.9599
+    time_from_start: {nsecs: 527400000, secs: 1}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_knee:
+  - position: 0.2443
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.5818
+  - position: 1.4835
+    time_from_start: {nsecs: 199999999, secs: 1}
+    velocity: 0.0
+  - position: 1.2217
+    time_from_start: {nsecs: 800000000, secs: 1}
+    velocity: -1.1109
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+name: right_close
+version: MV_stairsup_rightclose_v17

--- a/march_gait_files/training-v/stairs_up/right_open/MV_stairsup_rightopen_v17.subgait
+++ b/march_gait_files/training-v/stairs_up/right_open/MV_stairsup_rightopen_v17.subgait
@@ -1,0 +1,74 @@
+description: The left hip goes to 0 deg during gait to tilt more forward.
+duration: {nsecs: 0, secs: 3}
+gait_type: stairs_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  left_hip_fe:
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 399999999, secs: 2}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.1454
+  left_knee:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 490000000, secs: 2}
+    velocity: 0.0
+  - position: 0.2443
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.5818
+  right_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_hip_fe:
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 1.309
+    time_from_start: {nsecs: 527400000, secs: 1}
+    velocity: -0.1018
+  - position: 0.3491
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_knee:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 1.7453
+    time_from_start: {nsecs: 320000000, secs: 1}
+    velocity: 0.0
+  - position: 0.4189
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+name: right_open
+version: MV_stairsup_rightopen_v17

--- a/march_gait_files/training-v/stairs_up/right_swing/MV_stairsup_rightswing_v17.subgait
+++ b/march_gait_files/training-v/stairs_up/right_swing/MV_stairsup_rightswing_v17.subgait
@@ -1,0 +1,72 @@
+description: Right swing of the stairs up gait in which the right leg streches already
+  in this subgait
+duration: {nsecs: 0, secs: 3}
+gait_type: stairs_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  left_hip_fe:
+  - position: 0.3491
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.1454
+  left_knee:
+  - position: 0.4189
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 490000000, secs: 2}
+    velocity: 0.0
+  - position: 0.2443
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.5818
+  right_ankle:
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_hip_fe:
+  - position: -0.0873
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.1454
+  - position: 1.309
+    time_from_start: {nsecs: 399999999, secs: 1}
+    velocity: -0.1018
+  - position: 0.3491
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+  right_knee:
+  - position: 0.2443
+    time_from_start: {nsecs: 0, secs: 0}
+    velocity: 0.5818
+  - position: 1.7453
+    time_from_start: {nsecs: 100000000, secs: 1}
+    velocity: -0.4363
+  - position: 0.4189
+    time_from_start: {nsecs: 0, secs: 3}
+    velocity: 0.0
+name: right_swing
+version: MV_stairsup_rightswing_v17


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
--> I moved the new single_step_mini and stairs_up version 17 to training-v and set them as default. These two gaits have already been groundgaited. I also moved the new, slower, swings of the slalom to training-v already, but have not set them as default. These subgaits have not been groundgaited yet, but this can be done on Friday.

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
